### PR TITLE
Make cards generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +28,7 @@ dependencies = [
  "serde",
  "strum",
  "strum_macros",
+ "uuid",
 ]
 
 [[package]]
@@ -43,10 +50,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "js-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "ppv-lite86"
@@ -174,12 +197,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasi"
 version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,14 @@ strum = "0.27.1"
 strum_macros = "0.27.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
+[dependencies.uuid]
+version = "1.18.1"
+# Lets you generate random UUIDs
+features = [
+    "v4",
+    "serde",
+]
+
 [features]
 serde = ["dep:serde"]
 default = []

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -17,7 +17,7 @@ pub mod std_playing_cards;
 
 pub use card::{Card, CardFaces};
 pub use deck::Deck;
-pub use hand::Hand;
+pub use hand::{Hand, Hand as CardHand};
 pub use pile::Pile;
 pub use std_playing_cards::{Rank, StandardCard, Suit};
 

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -1,929 +1,158 @@
 //! # Cards Module
 //!
-//! This module implements mechanics common to games played with a standard 52 playing-card deck,
-//! such as cards, decks, piles, and hands. Would perhaps one day like to add the capability to
-//! handle other sorts of cards (Uno, Old Maid, Memory, etc.).
+//! This `gametools` module provides helpful tools for working with cards of
+//! any type. `Card` is generic over T where T implements the `CardFaces` trait,
+//! which defines how the front and back faces of the card are represented and
+//! how/if they can be matched and compared.
 //!
-//! # Example
-//! ```
-//! use gametools::{Deck, CardHand, Pile, AddCard, TakeCard};
-//! use gametools::{Suit, Rank, Card};
-//! use gametools::{GameResult};
+//! Unlike the prior implementation, this makes this version of the `cards` module useful
+//! for any kind of card: playing cards, Uno cards, Tarot, MAGIC, flashcards, etc.
 //!
-//! fn main() -> GameResult<()> {
-//!    let mut deck = Deck::standard_52("main deck");
-//!    let mut hand = CardHand::new("player_1");
-//!    let mut discard_pile = Pile::new("discard");
 //!
-//!    // shuffle and draw 7 cards into the hand
-//!    deck.shuffle();
-//!    hand.draw_cards_from(&mut deck, 7)?;
-//!    println!("{hand}");
-//!
-//!    // or deal from the deck to multiple hands
-//!    let mut other_hands = vec![CardHand::new("player_2"), CardHand::new("player_3")];
-//!    deck.deal_to_hands(&mut other_hands, 7)?;
-//!
-//!    // count ranks and suits
-//!    let num_spades = hand.count_suit(Suit::Spades);
-//!    let num_queens = hand.count_rank(Rank::Queen);
-//!
-//!    // search for a card in a hand
-//!    let search_card = Card::new_temp(Rank::Ace, Suit::Clubs);
-//!    let go_fish = hand.contains(&search_card);
-//!
-//!    // move a card from hand to another hand or a pile; returns an error if card is not in hand
-//!    if let Err(e) = hand.transfer_card(&search_card,&mut discard_pile) {
-//!         println!("error: {e}")
-//!    };
-//!
-//!    Ok(())
-//! }
-//!
-//! ```
+pub mod card;
+pub mod deck;
+pub mod hand;
+pub mod pile;
+pub mod std_playing_cards;
 
-// strum crate allows up to easily iterate through enums -- makes deck creation easy
-use rand::seq::SliceRandom;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use std::fmt::Display;
-use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
+pub use card::{Card, CardFaces};
+pub use deck::Deck;
+pub use hand::Hand;
+pub use pile::Pile;
+pub use std_playing_cards::{Rank, StandardCard, Suit};
 
-use crate::{GameError, GameResult};
-
-/// Represents all possible ranks (face values) for a standard playing card.
-#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, EnumIter)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "camelCase"))]
-pub enum Rank {
-    Two,
-    Three,
-    Four,
-    Five,
-    Six,
-    Seven,
-    Eight,
-    Nine,
-    Ten,
-    Jack,
-    Queen,
-    King,
-    Ace,
-}
-impl Rank {
-    /// Returns static string representation of each variant.
-    pub fn as_str(&self) -> &'static str {
-        match &self {
-            Rank::Two => "Two",
-            Rank::Three => "Three",
-            Rank::Four => "Four",
-            Rank::Five => "Five",
-            Rank::Six => "Six",
-            Rank::Seven => "Seven",
-            Rank::Eight => "Eight",
-            Rank::Nine => "Nine",
-            Rank::Ten => "Ten",
-            Rank::Jack => "Jack",
-            Rank::Queen => "Queen",
-            Rank::King => "King",
-            Rank::Ace => "Ace",
-        }
-    }
-}
-
-/// Represents the four possible suits of a standard playing card.
-#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, EnumIter)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "camelCase"))]
-pub enum Suit {
-    Clubs,
-    Diamonds,
-    Spades,
-    Hearts,
-}
-impl Suit {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Suit::Clubs => "Clubs",
-            Suit::Diamonds => "Diamonds",
-            Suit::Spades => "Spades",
-            Suit::Hearts => "Hearts",
-        }
-    }
-}
-
-/// Trait common to any collection from which you can remove a card or cards.
-pub trait TakeCard {
-    fn draw(&mut self) -> Option<Card>;
-    fn draw_cards(&mut self, count: usize) -> Option<Vec<Card>>;
+/// Methods common to all the different types of card collections
+pub trait CardCollection {
+    /// Determine the number of cards in the collection.
     fn size(&self) -> usize;
-    fn name(&self) -> String; // needed for GameError report when empty
+    /// Turn all of the cards face-up / front showing.
+    fn show_faces(&mut self);
+    /// Turn all of the cards face-down / back showing.
+    fn show_backs(&mut self);
 }
 
-/// Trait common to any collection to which you can add cards.
-pub trait AddCard {
-    /// Adds a single card to the collection.
-    fn add_card(&mut self, card: Card);
-    /// Adds multiple cards to the collection.
-    fn add_cards(&mut self, cards: &mut Vec<Card>);
-}
-
-/// A standard playing card.
-///
-/// New cards for use in gameplay should only be created by constructing a Deck. They will have a uid < u32::MAX
-/// and always start face down. Temporary cards for use in comparisons and searches can be created individually,
-/// but will always have a uid of u32::MAX and start face up.
-///
-/// ```rust
-/// use gametools::Card;
-/// use gametools::Rank::*;
-/// use gametools::Suit::*;
-///
-/// let search_card = Card::new_temp(Queen, Spades);
-/// assert_eq!(search_card.uid, u32::MAX);
-/// assert!(search_card.face_up, "temporary cards have no need to be hidden from view");
-/// assert_eq!(search_card.rank, Queen);
-/// assert_eq!(search_card.suit, Spades);
-///
-/// if search_card.uid == u32::MAX {
-///     println!("You created a temporary {search_card}.");
-/// } else {
-///     println!("Oops! This is a playable {search_card} from a deck!");
-/// }
-///
-/// ```
-#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct Card {
-    pub rank: Rank,
-    pub suit: Suit,
-    pub uid: u32,
-    pub face_up: bool,
-}
-impl Display for Card {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[{} of {}]", self.rank.as_str(), self.suit.as_str())
-    }
-}
-impl PartialEq for Card {
-    /// Determines whether this card is the same as another, using only rank and suit
-    /// (ignoring metadata like uid and face_up status)
-    fn eq(&self, other: &Self) -> bool {
-        self.rank == other.rank && self.suit == other.suit
-    }
-}
-impl Card {
-    /// Creates a new temporary card for search / comparison purposes. The uid
-    /// can be used to distinguish it from a card from a deck that actually belongs in play.
-    ///
-    /// ```rust
-    /// use gametools::{Card, Rank, Suit};
-    ///
-    /// let search_card = Card::new_temp( Rank::Queen, Suit::Spades );
-    /// assert!(search_card.uid == u32::MAX, "oops! cards with uid < u32::MAX are playable")
-    /// ```
-    pub fn new_temp(rank: Rank, suit: Suit) -> Self {
-        Self {
-            rank,
-            suit,
-            uid: u32::MAX,
-            face_up: true,
+/// Methods shared by card collections that allow cards to be added to them.
+pub trait AddCard<T: CardFaces> {
+    /// Add one card to the collection.
+    fn add_card(&mut self, card: Card<T>);
+    /// Add a list of cards to the collection.
+    fn add_cards(&mut self, cards: Vec<Card<T>>) {
+        for card in cards {
+            self.add_card(card);
         }
     }
 }
 
-/// A deck of playing cards. A card source.
-///
-/// Cards can be only *removed* from a deck until it is empty. If more cards
-/// are needed, a new deck must be created. This is unlike a Pile, to which
-/// cards can also be added.
-#[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "camelCase"))]
-pub struct Deck {
-    pub name: String,
-    cards: Vec<Card>,
-}
-impl TakeCard for Deck {
-    /// Takes a card from the deck.
+/// Methods shared by card collections that allow cards to be removed.
+pub trait TakeCard<T: CardFaces> {
+    /// Take a `Card` (typically the top or last added) from a collection.
+    fn take_card(&mut self) -> Option<Card<T>>;
+    /// Take `count` `Cards` from a collection.
     ///
-    /// ```rust
-    /// use gametools::{Deck, TakeCard};
-    ///
-    /// let mut deck = Deck::standard_52("main deck");
-    ///
-    /// let drawn = deck.draw().unwrap();    // OK here, new deck always full
-    /// println!("you drew: {drawn}");
-    /// ```
-    fn draw(&mut self) -> Option<Card> {
-        self.cards.pop()
-    }
-
-    /// Takes multiple cards from the deck. Returns None if the deck doesn't have enough to fill the request.
-    ///
-    /// ```rust
-    /// use gametools::{Deck, TakeCard};
-    ///
-    /// let mut deck = Deck::standard_52("test_deck");
-    ///
-    /// let three_cards = deck.draw_cards(3).unwrap();  // OK, new deck has > 3 cards here
-    /// assert_eq!(deck.size(), 52 - 3);
-    /// assert_eq!(three_cards.len(), 3);
-    ///
-    /// for card in three_cards {
-    ///     println!("{card}");
-    /// }
-    /// ```
-    fn draw_cards(&mut self, count: usize) -> Option<Vec<Card>> {
-        if count > self.cards.len() {
-            return None;
-        }
-        Some(self.cards.split_off(self.cards.len() - count))
-    }
-
-    /// Returns a string containing the deck's name for error reporting and display purposes
-    fn name(&self) -> String {
-        self.name.clone()
-    }
-
-    fn size(&self) -> usize {
-        self.cards.len()
-    }
-}
-impl Deck {
-    /// Creates a new, standard 52-card deck of playing cards.
-    ///
-    /// ```rust
-    /// use gametools::{Deck,Card,TakeCard};
-    /// use gametools::Rank::*;
-    /// use gametools::Suit::*;
-    ///
-    /// let deck = Deck::standard_52("standard playing cards");
-    ///
-    /// let size = deck.size();
-    /// assert_eq!(size, 52);
-    ///
-    /// let count_fives = deck.iter().filter(|&card| card.rank == Five).count();
-    /// assert_eq!(count_fives, 4);
-    ///
-    /// let count_qos = deck.iter()
-    ///                     .filter(|&card| matches!(*card, Card{ rank: Queen, suit: Spades, ..}))
-    ///                     .count();
-    /// assert_eq!(count_qos, 1);
-    /// ```
-    pub fn standard_52(name: &str) -> Self {
-        let mut cards = Vec::<Card>::new();
-        let mut uid = 0;
-        for suit in Suit::iter() {
-            for rank in Rank::iter() {
-                cards.push(Card {
-                    rank,
-                    suit,
-                    uid,
-                    face_up: false,
-                });
-                uid += 1;
+    /// May return fewer than requested if the source collection runs dry or
+    /// is already empty.
+    fn take_cards(&mut self, count: usize) -> Vec<Card<T>> {
+        let mut cards = Vec::with_capacity(count);
+        for _ in 0..count {
+            if let Some(card) = self.take_card() {
+                cards.push(card);
+            } else {
+                break;
             }
         }
-        Self {
-            name: name.to_owned(),
-            cards,
-        }
+        cards
     }
-
-    /// Provides an iterator over references to the cards remaining in the deck.
-    pub fn iter(&self) -> impl Iterator<Item = &Card> {
-        self.cards.iter()
-    }
-
-    /// Provides a slice of references to the cards remaining in the deck.
-    pub fn as_slice(&self) -> &[Card] {
-        &self.cards
-    }
-
-    /// Shuffles the deck in place.
-    /// ```rust
-    /// use gametools::{Deck, TakeCard};
-    ///
-    /// let mut deck = Deck::standard_52("deck_id");
-    /// let original = deck.clone();
-    /// assert_eq!(deck, original);
-    /// deck.shuffle();
-    /// assert_eq!(deck.size(), original.size());
-    /// assert_ne!(deck, original);
-    /// ```
-    pub fn shuffle(&mut self) {
-        let mut rng = rand::rng();
-        self.cards.shuffle(&mut rng);
-    }
-
-    /// Deals a specified number of cards to one or more hands.
-    /// Returns a GameError if the deck doesn't contain enough cards to complete request for *all* hands.
-    ///
-    /// ```rust
-    /// use gametools::{Deck, CardHand, TakeCard};
-    ///
-    /// // create game deck
-    /// let mut war_deck = Deck::standard_52("War!");
-    /// war_deck.shuffle();
-    ///
-    /// // create (empty) hands for the players
-    /// let mut player_1 = CardHand::new("Frank");
-    /// let mut player_2 = CardHand::new("Dweezil");
-    /// let mut hands = vec![player_1, player_2];
-    ///
-    /// // deal 26 cards each to Frank and Dweezil
-    /// war_deck.deal_to_hands(&mut hands, 26).unwrap();
-    ///
-    /// assert_eq!(war_deck.size(), 0);
-    /// assert_eq!(hands[0].size(), 26);
-    /// assert_eq!(hands[1].size(), 26);
-    ///
-    /// ```
-    pub fn deal_to_hands(&mut self, hands: &mut Vec<CardHand>, count: usize) -> GameResult<()> {
-        // return Err immediately if there aren't enough cards left, so we don't
-        // have to partially fill hands before finding the end of the deck
-        if hands.len() * count > self.cards.len() {
-            return Err(GameError::StackTooSmall(self.name()));
-        }
-
-        for hand in hands {
-            hand.draw_cards_from(self, count)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// A stack of cards, such as a draw or discard pile. Last one added is first that will be drawn.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct Pile {
-    pub name: String,
-    pub cards: Vec<Card>,
-}
-impl TakeCard for Pile {
-    fn draw(&mut self) -> Option<Card> {
-        self.cards.pop()
-    }
-
-    fn draw_cards(&mut self, count: usize) -> Option<Vec<Card>> {
-        if count > self.cards.len() {
-            return None;
-        }
-        Some(self.cards.split_off(self.cards.len() - count))
-    }
-    /// Returns the name of the pile.
-    fn name(&self) -> String {
-        self.name.clone()
-    }
-    /// Returns the size of the pile (in cards).
-    fn size(&self) -> usize {
-        self.cards.len()
-    }
-}
-impl Pile {
-    /// Create a new empty pile of cards.
-    ///
-    /// ```
-    /// use gametools::{Pile, TakeCard};
-    /// let mut discard_pile = Pile::new("Discard");
-    /// assert_eq!(discard_pile.size(), 0);
-    /// ```
-    pub fn new(name: &str) -> Self {
-        Self {
-            name: name.to_owned(),
-            cards: Vec::<Card>::new(),
-        }
-    }
-}
-impl AddCard for Pile {
-    /// Add a card to the top of the pile.
-    /// ```
-    /// # use gametools::{Pile, Card, Deck, TakeCard, AddCard, GameResult};
-    /// # fn main() -> GameResult<()> {
-    ///     let mut pile = Pile::new("Discard");
-    ///     let mut deck = Deck::standard_52("Game Deck");
-    ///     deck.shuffle();
-    ///
-    ///     let card = deck.draw().unwrap();
-    ///     pile.add_card(card);
-    ///
-    ///     assert_eq!(pile.size(), 1);
-    ///     assert_eq!(deck.size(), 51);
-    /// # Ok(())
-    /// }
-    /// ```
-    fn add_card(&mut self, card: Card) {
-        self.cards.push(card);
-    }
-
-    fn add_cards(&mut self, cards: &mut Vec<Card>) {
-        self.cards.append(cards);
-    }
-}
-
-/// A player's hand of cards in a game.
-#[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct CardHand {
-    pub player: String,
-    pub cards: Vec<Card>,
-}
-
-impl Display for CardHand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut display_string = format!("{}:[", self.player);
-        for card in &self.cards {
-            display_string.push_str(&card.to_string());
-        }
-        display_string.push(']');
-        write!(f, "{}", display_string)
-    }
-}
-impl AddCard for CardHand {
-    fn add_card(&mut self, card: Card) {
-        self.cards.push(card);
-    }
-
-    fn add_cards(&mut self, cards: &mut Vec<Card>) {
-        self.cards.append(cards);
-    }
-}
-
-impl CardHand {
-    /// Takes a player name or ID and returns a new empty hand.
-    pub fn new(player: &str) -> Self {
-        Self {
-            player: player.to_string(),
-            cards: Vec::<Card>::new(),
-        }
-    }
-
-    /// Draws a card from the specified Deck or Pile.
-    /// Returns Err if deck is empty.
-    pub fn draw_card_from(&mut self, stack: &mut impl TakeCard) -> GameResult<()> {
-        let drawn = match stack.draw() {
-            Some(card) => card,
-            None => return Err(GameError::StackEmpty(stack.name())),
-        };
-        self.cards.push(drawn);
-        Ok(())
-    }
-
-    /// Draws a specified number of cards from a Deck or a Pile
-    /// Returns Err() if there aren't enough cards to fulfill the request.
-    pub fn draw_cards_from(&mut self, stack: &mut impl TakeCard, count: usize) -> GameResult<()> {
-        let mut drawn = match stack.draw_cards(count) {
-            Some(cards) => cards,
-            None => return Err(GameError::StackTooSmall(stack.name())),
-        };
-        self.cards.append(&mut drawn);
-        Ok(())
-    }
-
-    /// Returns the number of cards currently in the hand.
-    pub fn size(&self) -> usize {
-        self.cards.len()
-    }
-
-    /// Returns true if a specified card is found in the hand.
-    pub fn contains(&self, temp_card: &Card) -> bool {
-        self.cards.contains(temp_card)
-    }
-
-    /// Returns true if a card of specified Rank and Suit is in the hand.
-    pub fn contains_by_rs(&self, rank: Rank, suit: Suit) -> bool {
-        self.cards.contains(&Card::new_temp(rank, suit))
-    }
-
-    /// Transfer a card from this hand to another collection.
-    ///
-    /// The other collection can be a Pile, a Hand or anything that implements AddCard.
-    /// Returns a GameError::CardNotFound if you try to transfer a card that isn't there.
-    /// ```
-    /// # use gametools::*;
-    /// # fn main() -> GameResult<()> {
-    /// let mut deck = Deck::standard_52("test");
-    /// let mut hand = CardHand::new("player 1");
-    /// let mut other = CardHand::new("player 2");
-    ///
-    /// // Since we haven't shuffled the deck, this will put the
-    /// // Ace, King, and Queen of Hearts into the hand
-    /// hand.draw_cards_from(&mut deck, 3)?;
-    ///
-    /// // Transfer the Ace into the other hand
-    /// let search_card = Card::new_temp(Rank::Ace, Suit::Hearts);
-    /// hand.transfer_card(&search_card, &mut other)?;
-    ///
-    /// assert_eq!(deck.size(), 49);
-    /// assert_eq!(hand.size(), 2);
-    /// assert!(other.contains(&search_card));
-    /// assert!(!hand.contains(&search_card));
-    ///
-    /// # Ok(())
-    /// # }
-    ///
-    /// ```
-    pub fn transfer_card(&mut self, temp_card: &Card, other: &mut impl AddCard) -> GameResult<()> {
-        match self.cards.iter().position(|&c| c == *temp_card) {
-            Some(pos) => {
-                let real_card = self.cards.remove(pos);
-                other.add_card(real_card);
-            }
-            None => return Err(GameError::CardNotFound),
-        }
-        Ok(())
-    }
-
-    /// Count the cards in the hand matching a given rank.
-    pub fn count_rank(&self, rank: Rank) -> usize {
-        self.cards.iter().filter(|&c| c.rank == rank).count()
-    }
-
-    /// Count the cards in the hand matching a given suit.
-    pub fn count_suit(&self, suit: Suit) -> usize {
-        self.cards.iter().filter(|&c| c.suit == suit).count()
-    }
+    /// Take the `Card` matching the `search_card` from the collection, if it exists.
+    fn take_match(&mut self, search_card: &Card<T>) -> Option<Card<T>>;
 }
 
 #[cfg(test)]
-mod card_tests {
-    use crate::cards::*;
+mod tests {
+    use super::*;
 
-    #[test]
-    fn rank_as_str_works() {
-        assert_eq!(Rank::Two.as_str(), "Two");
-        assert_eq!(Rank::Three.as_str(), "Three");
-        assert_eq!(Rank::Four.as_str(), "Four");
-        assert_eq!(Rank::Five.as_str(), "Five");
-        assert_eq!(Rank::Six.as_str(), "Six");
-        assert_eq!(Rank::Seven.as_str(), "Seven");
-        assert_eq!(Rank::Eight.as_str(), "Eight");
-        assert_eq!(Rank::Nine.as_str(), "Nine");
-        assert_eq!(Rank::Ten.as_str(), "Ten");
-        assert_eq!(Rank::Jack.as_str(), "Jack");
-        assert_eq!(Rank::Queen.as_str(), "Queen");
-        assert_eq!(Rank::King.as_str(), "King");
-        assert_eq!(Rank::Ace.as_str(), "Ace");
+    #[derive(Debug, Clone, PartialEq)]
+    struct StubFaces {
+        id: u8,
     }
 
-    #[test]
-    fn suit_as_str_works() {
-        assert_eq!(Suit::Clubs.as_str(), "Clubs");
-        assert_eq!(Suit::Diamonds.as_str(), "Diamonds");
-        assert_eq!(Suit::Hearts.as_str(), "Hearts");
-        assert_eq!(Suit::Spades.as_str(), "Spades");
-    }
-
-    #[test]
-    fn card_display_is_correct() {
-        let qos = Card::new_temp(Rank::Queen, Suit::Spades);
-        assert_eq!(qos.to_string(), "[Queen of Spades]".to_string());
-    }
-
-    #[test]
-    fn deck_iter_works() {
-        let deck = Deck::standard_52("test");
-        assert_eq!(deck.iter().count(), 52);
-    }
-
-    #[test]
-    fn deck_as_slice_works() {
-        let deck = Deck::standard_52("test");
-        for card in deck.as_slice() {
-            assert!(card.uid < u32::MAX);
+    impl CardFaces for StubFaces {
+        fn display_front(&self) -> String {
+            format!("front-{}", self.id)
         }
-        assert_eq!(deck.as_slice().iter().count(), 52);
+        fn display_back(&self) -> Option<String> {
+            None
+        }
+        fn matches(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+        fn compare(&self, other: &Self) -> std::cmp::Ordering {
+            self.id.cmp(&other.id)
+        }
     }
 
-    #[test]
-    fn deck_shuffle_works() {
-        let original = Deck::standard_52("test");
-        let mut copy = original.clone();
-        assert_eq!(original, copy);
-        copy.shuffle();
-        assert_eq!(original.size(), copy.size());
-        assert_ne!(original, copy);
+    #[derive(Debug, Default)]
+    struct StubCollection {
+        cards: Vec<Card<StubFaces>>,
     }
 
-    #[test]
-    fn deck_standard_52_works() {
-        let deck = Deck::standard_52("Standard/Test Deck");
-
-        let spade_count = deck
-            .cards
-            .iter()
-            .filter(|&c| c.suit == Suit::Spades)
-            .count();
-        let jack_count = deck.cards.iter().filter(|&c| c.rank == Rank::Jack).count();
-        let heart_count = deck
-            .cards
-            .iter()
-            .filter(|&c| c.suit == Suit::Hearts)
-            .count();
-        let two_count = deck.cards.iter().filter(|&c| c.rank == Rank::Two).count();
-        let all_count = deck.cards.len();
-
-        assert_eq!(spade_count, 13);
-        assert_eq!(jack_count, 4);
-        assert_eq!(heart_count, 13);
-        assert_eq!(two_count, 4);
-        assert_eq!(all_count, 52);
+    impl AddCard<StubFaces> for StubCollection {
+        fn add_card(&mut self, card: Card<StubFaces>) {
+            self.cards.push(card);
+        }
     }
 
-    #[test]
-    fn deck_draw_works() {
-        let mut deck = Deck::standard_52("test deck");
-        let Card { rank, suit, .. } = deck
-            .draw()
-            .expect("should be able to draw from new full deck");
-        let remaining_of_rank = deck.cards.iter().filter(|&c| c.rank == rank).count();
-        let remaining_of_suit = deck.cards.iter().filter(|&c| c.suit == suit).count();
-
-        assert_eq!(deck.cards.len(), 51);
-        assert_eq!(remaining_of_rank, 3);
-        assert_eq!(remaining_of_suit, 12);
-    }
-
-    #[test]
-    fn deck_draw_cards_works() {
-        let mut deck = Deck::standard_52("test deck");
-        let hand = deck
-            .draw_cards(5)
-            .expect("should be able to draw 5 from fresh deck");
-        assert_eq!(hand.len(), 5);
-        assert_eq!(deck.cards.len(), 47);
-
-        let huge_hand = deck.draw_cards(100);
-        assert_eq!(huge_hand, None)
-    }
-
-    #[test]
-    fn deck_deal_to_hands_works() -> Result<(), Box<dyn std::error::Error>> {
-        let mut deck = Deck::standard_52("standard 52-card deck");
-
-        // create a pool of empty hands
-        let num_hands = 4;
-        let num_cards = 5;
-        let mut hands = Vec::<CardHand>::new();
-        for n in 1..=num_hands {
-            hands.push(CardHand::new(&format!("Player {n}")));
+    impl TakeCard<StubFaces> for StubCollection {
+        fn take_card(&mut self) -> Option<Card<StubFaces>> {
+            self.cards.pop()
         }
 
-        // deal 'em
-        deck.deal_to_hands(&mut hands, num_cards)?;
-
-        //dbg!(&hands); // uncomment to show all hands after deal
-        assert_eq!(deck.cards.len(), 52 - (num_cards * num_hands));
-        assert_eq!(hands.len(), num_hands);
-
-        // do all hands have the right # of cards?
-        for hand in &hands {
-            assert_eq!(hand.cards.len(), num_cards);
+        fn take_match(&mut self, search_card: &Card<StubFaces>) -> Option<Card<StubFaces>> {
+            let idx = self
+                .cards
+                .iter()
+                .position(|card| card.faces.matches(&search_card.faces));
+            idx.map(|i| self.cards.remove(i))
         }
+    }
 
-        // should Err if we request too many
-        let too_many = deck.deal_to_hands(&mut hands, 100);
-        assert!(
-            matches!(too_many, Err(_)),
-            "too-many request should have returned Err from deal_to_hands"
-        );
-
-        Ok(())
+    fn make_card(id: u8) -> Card<StubFaces> {
+        Card::new_card(StubFaces { id })
     }
 
     #[test]
-    fn pile_add_card_works() {
-        let mut pile = Pile::new("p1");
-        pile.add_card(Card::new_temp(Rank::Ace, Suit::Clubs));
-        assert_eq!(pile.size(), 1);
+    fn add_cards_adds_each_card_in_order() {
+        let mut collection = StubCollection::default();
+        let cards = vec![make_card(1), make_card(2), make_card(3)];
+
+        collection.add_cards(cards.clone());
+
+        assert_eq!(collection.cards.len(), 3);
+        let ids: Vec<u8> = collection.cards.iter().map(|card| card.faces.id).collect();
+        assert_eq!(ids, vec![1, 2, 3]);
     }
 
     #[test]
-    fn pile_add_cards_works() {
-        let mut pile = Pile::new("p1");
-        let mut some_cards = vec![
-            Card::new_temp(Rank::King, Suit::Diamonds),
-            Card::new_temp(Rank::Ten, Suit::Hearts),
-            Card::new_temp(Rank::Queen, Suit::Spades),
-        ];
-        pile.add_cards(&mut some_cards);
-        assert_eq!(pile.size(), 3);
+    fn take_cards_respects_count_and_order() {
+        let mut collection = StubCollection::default();
+        collection.cards = vec![make_card(1), make_card(2), make_card(3)];
+
+        let taken = collection.take_cards(2);
+
+        assert_eq!(taken.len(), 2);
+        assert_eq!(taken[0].faces.id, 3);
+        assert_eq!(taken[1].faces.id, 2);
+        assert_eq!(collection.cards.len(), 1);
+        assert_eq!(collection.cards[0].faces.id, 1);
     }
 
     #[test]
-    fn pile_draw_works() {
-        let mut pile = Pile::new("discard");
-        let mut some_cards = vec![
-            Card::new_temp(Rank::King, Suit::Diamonds),
-            Card::new_temp(Rank::Ten, Suit::Hearts),
-            Card::new_temp(Rank::Queen, Suit::Spades),
-        ];
-        pile.add_cards(&mut some_cards);
+    fn take_cards_stops_when_collection_is_empty() {
+        let mut collection = StubCollection::default();
+        collection.cards = vec![make_card(5)];
 
-        // top card should be the last one added
-        let top_card = pile.draw().unwrap();
-        assert_eq!(top_card, Card::new_temp(Rank::Queen, Suit::Spades));
+        let taken = collection.take_cards(3);
 
-        // draw from an empty pile should return None
-        let mut empty_pile = Pile::new("test");
-        assert!(empty_pile.draw().is_none());
-    }
-
-    #[test]
-    fn pile_draw_cards_works() {
-        let mut pile = Pile::new("discard");
-        let mut some_cards = vec![
-            Card::new_temp(Rank::King, Suit::Diamonds),
-            Card::new_temp(Rank::Ten, Suit::Hearts),
-            Card::new_temp(Rank::Queen, Suit::Spades),
-        ];
-        pile.add_cards(&mut some_cards);
-        let take_two = pile.draw_cards(2).unwrap();
-        let expected = vec![
-            Card::new_temp(Rank::Ten, Suit::Hearts),
-            Card::new_temp(Rank::Queen, Suit::Spades),
-        ];
-        assert_eq!(take_two, expected);
-
-        // attempt to draw too many should return None
-        assert!(pile.draw_cards(1000).is_none());
-    }
-
-    #[test]
-    fn pile_name_works() {
-        let pile = Pile::new("test");
-        assert_eq!(pile.name(), "test");
-    }
-
-    #[test]
-    fn pile_size_is_correct() {
-        let mut pile = Pile::new("test");
-        assert_eq!(pile.size(), 0);
-        pile.add_card(Card::new_temp(Rank::Ace, Suit::Hearts));
-        assert_eq!(pile.size(), 1);
-    }
-
-    #[test]
-    fn hand_display_is_correct() {
-        let mut hand = CardHand::new("test");
-        assert_eq!(hand.to_string(), "test:[]");
-        let qos = Card::new_temp(Rank::Queen, Suit::Spades);
-        hand.add_card(qos);
-        assert_eq!(hand.to_string(), "test:[[Queen of Spades]]");
-    }
-
-    #[test]
-    fn hand_draw_card_from_works() -> Result<(), Box<dyn std::error::Error>> {
-        let mut hand = CardHand::new("Player 1");
-        let mut deck = Deck::standard_52("standard test deck");
-
-        assert_eq!(hand.cards.len(), 0);
-        assert_eq!(deck.cards.len(), 52);
-
-        hand.draw_card_from(&mut deck)?;
-
-        assert_eq!(hand.cards.len(), 1);
-        assert_eq!(deck.cards.len(), 51);
-
-        let _ = deck.draw_cards(51); // empty the deck and try to draw again
-        let empty_draw = hand.draw_card_from(&mut deck);
-        assert!(
-            matches!(empty_draw, Err(_)),
-            "draw from empty deck should have returned err"
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn hand_draw_cards_from_works() -> Result<(), Box<dyn std::error::Error>> {
-        let mut hand = CardHand::new("frank zappa");
-        let mut deck = Deck::standard_52("the poodle bites");
-
-        hand.draw_cards_from(&mut deck, 5)?;
-        assert_eq!(hand.cards.len(), 5);
-        assert_eq!(deck.cards.len(), 47);
-
-        let too_many = hand.draw_cards_from(&mut deck, 500);
-        assert!(
-            matches!(too_many, Err(_)),
-            "attempt to draw too many cards should have returned Err()"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn hand_transfer_card_to_pile_works() -> GameResult<()> {
-        let mut deck = Deck::standard_52("test deck");
-        let mut pile = Pile::new("test pile");
-        let mut hand = CardHand::new("test hand");
-
-        // Since we haven't shuffled the deck, this will put the
-        // Ace, King, and Queen of Hearts into the hand
-        hand.draw_cards_from(&mut deck, 3)
-            .expect("deck just created should have >3 cards!");
-
-        // Transfer a card we know is in the hand to the pile
-        let search_card = Card::new_temp(Rank::Queen, Suit::Hearts);
-        hand.transfer_card(&search_card, &mut pile)?;
-        assert_eq!(pile.size(), 1);
-        assert_eq!(hand.size(), 2);
-
-        // Should return Err if we try to transfer a card that isn't there
-        let search_card = Card::new_temp(Rank::Queen, Suit::Spades);
-        assert!(
-            hand.transfer_card(&search_card, &mut pile).is_err(),
-            "should not be able to transfer an absent card"
-        );
-        Ok(())
-    }
-    #[test]
-    fn hand_transfer_card_to_hand_works() -> GameResult<()> {
-        let mut deck = Deck::standard_52("test deck");
-        let mut hand = CardHand::new("test hand");
-        let mut other = CardHand::new("other hand");
-
-        // Since we haven't shuffled the deck, this will put the
-        // Ace, King, and Queen of Hearts into the hand
-        hand.draw_cards_from(&mut deck, 3)
-            .expect("deck just created should have >3 cards!");
-
-        // Transfer a card we know is in the hand to the other hand
-        let search_card = Card::new_temp(Rank::Queen, Suit::Hearts);
-        hand.transfer_card(&search_card, &mut other)?;
-        assert_eq!(other.size(), 1);
-        assert_eq!(hand.size(), 2);
-
-        // Should return Err if we try to transfer a card that isn't there
-        let search_card = Card::new_temp(Rank::Queen, Suit::Spades);
-        assert!(
-            hand.transfer_card(&search_card, &mut other).is_err(),
-            "should not be able to transfer an absent card"
-        );
-        Ok(())
-    }
-    #[test]
-    fn hand_count_rank_works() {
-        let mut hand = CardHand::new("p1");
-        hand.add_card(Card::new_temp(Rank::Queen, Suit::Spades));
-        hand.add_card(Card::new_temp(Rank::Queen, Suit::Clubs));
-        hand.add_card(Card::new_temp(Rank::Three, Suit::Spades));
-        assert_eq!(hand.count_rank(Rank::Queen), 2);
-        assert_eq!(hand.count_rank(Rank::Three), 1);
-        assert_eq!(hand.count_rank(Rank::Jack), 0);
-    }
-
-    #[test]
-    fn hand_count_suit_works() {
-        let mut hand = CardHand::new("p1");
-        hand.add_card(Card::new_temp(Rank::Queen, Suit::Spades));
-        hand.add_card(Card::new_temp(Rank::Queen, Suit::Clubs));
-        hand.add_card(Card::new_temp(Rank::Three, Suit::Spades));
-        assert_eq!(hand.count_suit(Suit::Clubs), 1);
-        assert_eq!(hand.count_suit(Suit::Spades), 2);
-        assert_eq!(hand.count_suit(Suit::Hearts), 0)
-    }
-    #[test]
-    fn hand_contains_works() {
-        let mut hand = CardHand::new("test");
-        hand.add_card(Card::new_temp(Rank::Queen, Suit::Spades));
-
-        assert!(hand.contains(&Card::new_temp(Rank::Queen, Suit::Spades)));
-        assert!(!hand.contains(&Card::new_temp(Rank::Ten, Suit::Clubs)));
-    }
-
-    #[test]
-    fn hand_contains_rs_works() {
-        let mut hand = CardHand::new("test");
-        let temp_card = Card::new_temp(Rank::Ace, Suit::Diamonds);
-        hand.add_card(temp_card);
-
-        assert!(hand.contains_by_rs(Rank::Ace, Suit::Diamonds));
-        assert!(!hand.contains_by_rs(Rank::Jack, Suit::Clubs));
-    }
-
-    #[test]
-    fn hand_add_card_works() {
-        let mut hand = CardHand::new("p1");
-        hand.add_card(Card::new_temp(Rank::Ace, Suit::Clubs));
-        assert_eq!(hand.size(), 1);
-    }
-
-    #[test]
-    fn hand_add_cards_works() {
-        let mut hand = CardHand::new("p1");
-        let mut some_cards = vec![
-            Card::new_temp(Rank::King, Suit::Diamonds),
-            Card::new_temp(Rank::Ten, Suit::Hearts),
-            Card::new_temp(Rank::Queen, Suit::Spades),
-        ];
-        hand.add_cards(&mut some_cards);
-        assert_eq!(hand.size(), 3);
+        assert_eq!(taken.len(), 1);
+        assert!(collection.cards.is_empty());
     }
 }

--- a/src/cards/card.rs
+++ b/src/cards/card.rs
@@ -1,0 +1,154 @@
+//!
+//! card module
+//!
+//! Implements a card generic over T, where T: `CardFaces`. The `CardFaces` trait
+//! defines how each side of the card appears and how they compare to each other.
+
+use uuid::Uuid;
+
+/// A generic card of any kind, as long as it has faces.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Card<T: CardFaces> {
+    pub faces: T,
+    pub uuid: Uuid,
+    pub face_up: bool,
+}
+
+pub trait CardFaces {
+    fn display_front(&self) -> String;
+    fn display_back(&self) -> Option<String>;
+    fn matches(&self, other: &Self) -> bool;
+    fn compare(&self, other: &Self) -> std::cmp::Ordering;
+}
+
+impl<T: CardFaces> Card<T> {
+    pub fn new_card(faces: T) -> Card<T> {
+        Card {
+            faces,
+            uuid: Uuid::new_v4(),
+            face_up: true,
+        }
+    }
+    pub fn flip(&mut self) {
+        self.face_up = !self.face_up;
+    }
+}
+
+impl<T: CardFaces> std::fmt::Display for Card<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.face_up {
+            write!(f, "{}", self.faces.display_front())
+        } else {
+            write!(
+                f,
+                "{}",
+                self.faces
+                    .display_back()
+                    .unwrap_or_else(|| "|Face Down|".to_string())
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct StubFaces {
+        front: &'static str,
+        back: Option<&'static str>,
+        match_id: u8,
+        score: i16,
+    }
+
+    impl CardFaces for StubFaces {
+        fn display_front(&self) -> String {
+            self.front.to_string()
+        }
+
+        fn display_back(&self) -> Option<String> {
+            self.back.map(|s| s.to_string())
+        }
+
+        fn matches(&self, other: &Self) -> bool {
+            self.match_id == other.match_id
+        }
+
+        fn compare(&self, other: &Self) -> std::cmp::Ordering {
+            self.score.cmp(&other.score)
+        }
+    }
+
+    fn make_card(score: i16, back: Option<&'static str>) -> Card<StubFaces> {
+        Card::new_card(StubFaces {
+            front: "front",
+            back,
+            match_id: 7,
+            score,
+        })
+    }
+
+    #[test]
+    fn new_card_initializes_face_up_with_unique_faces() {
+        let card = make_card(3, Some("back"));
+
+        assert!(card.face_up);
+        assert_eq!(card.faces.display_front(), "front");
+    }
+
+    #[test]
+    fn flip_toggles_face_orientation() {
+        let mut card = make_card(0, None);
+
+        card.flip();
+        assert!(!card.face_up);
+
+        card.flip();
+        assert!(card.face_up);
+    }
+
+    #[test]
+    fn display_shows_front_when_face_up() {
+        let card = make_card(1, Some("back"));
+        assert_eq!(card.to_string(), "front");
+    }
+
+    #[test]
+    fn display_prefers_back_when_face_down_and_available() {
+        let mut card = make_card(1, Some("back"));
+        card.flip();
+
+        assert_eq!(card.to_string(), "back");
+    }
+
+    #[test]
+    fn display_uses_default_when_face_down_without_back() {
+        let mut card = make_card(2, None);
+        card.flip();
+
+        assert_eq!(card.to_string(), "|Face Down|");
+    }
+
+    #[test]
+    fn compare_returns_expected_outcomes() {
+        let low = StubFaces {
+            front: "front",
+            back: None,
+            match_id: 1,
+            score: 1,
+        };
+        let mid = StubFaces {
+            score: 2,
+            ..low.clone()
+        };
+        let high = StubFaces {
+            score: 3,
+            ..low.clone()
+        };
+
+        assert_eq!(mid.compare(&low), std::cmp::Ordering::Greater);
+        assert_eq!(mid.compare(&high), std::cmp::Ordering::Less);
+        assert_eq!(mid.compare(&mid), std::cmp::Ordering::Equal);
+    }
+}

--- a/src/cards/card.rs
+++ b/src/cards/card.rs
@@ -6,8 +6,12 @@
 
 use uuid::Uuid;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// A generic card of any kind, as long as it has faces.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Card<T: CardFaces> {
     pub faces: T,
     pub uuid: Uuid,

--- a/src/cards/card.rs
+++ b/src/cards/card.rs
@@ -9,12 +9,17 @@ use uuid::Uuid;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::Deck;
+
+use super::deck::DeckId;
+
 /// A generic card of any kind, as long as it has faces.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Card<T: CardFaces> {
     pub faces: T,
     pub uuid: Uuid,
+    pub deck_id: Option<DeckId>,
     pub face_up: bool,
 }
 
@@ -26,15 +31,32 @@ pub trait CardFaces {
 }
 
 impl<T: CardFaces> Card<T> {
+    /// Create a new card from a struct that is CardFaces.
+    ///
+    /// By default, there are orphan or dummy cards that don't belong to a Deck. A DeckId
+    /// is assigned to them if they are passed through Deck::new() or Deck::new_from_faces().
     pub fn new_card(faces: T) -> Card<T> {
         Card {
             faces,
             uuid: Uuid::new_v4(),
+            deck_id: None,
             face_up: true,
         }
     }
+    /// Flip the card over.
+    ///
+    /// This changes which side of the card is visible. Display is implemented so that printing
+    /// {card} shows the face from whichever side is up.
     pub fn flip(&mut self) {
         self.face_up = !self.face_up;
+    }
+    /// Determine whether this card belongs to a specific `Deck`.
+    pub fn is_from_deck(&self, deck: Deck<T>) -> bool {
+        self.deck_id == Some(deck.deck_id)
+    }
+
+    pub fn assign_to_deck(&mut self, deck_id: DeckId) {
+        self.deck_id = Some(deck_id);
     }
 }
 

--- a/src/cards/deck.rs
+++ b/src/cards/deck.rs
@@ -1,7 +1,7 @@
 //! # Decks
 //!
 //! A [`Deck`] starts full and only loses cards through draw-like operations. It is the
-//! canonical source of cards for most games, pairing neatly with [`Hand`](crate::cards::hand::Hand)
+//! canonical source of cards for most games, pairing neatly with [`Hand`]
 //! or [`Pile`](crate::cards::pile::Pile) to model game flow.
 //!
 //! # Examples

--- a/src/cards/deck.rs
+++ b/src/cards/deck.rs
@@ -1,0 +1,188 @@
+//! deck module
+//!
+//! Represents a `Deck` of `Card<T>`
+//! `Deck` differs from `Pile` in that a `Deck` begins full and only be drawn from.
+//! `Pile` starts empty and cards can be added to or taken from it.
+//!
+//! Implements: Debug, Clone, PartialEq, CardCollection, TakeCard
+
+use crate::cards::{AddCard, Card, CardCollection, CardFaces, Hand, TakeCard};
+use rand::prelude::*;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Deck<T: CardFaces> {
+    pub name: String,
+    pub cards: Vec<Card<T>>,
+}
+impl<T: CardFaces + Clone> Deck<T> {
+    pub fn new(name: &str, cards: Vec<Card<T>>) -> Self {
+        Self {
+            name: name.to_string(),
+            cards,
+        }
+    }
+
+    pub fn new_from_faces(name: &str, faces: &Vec<T>) -> Self {
+        let cards = faces.iter().map(|f| Card::new_card(f.clone())).collect();
+        Self::new(name, cards)
+    }
+
+    pub fn shuffle(&mut self) {
+        self.cards.shuffle(&mut rand::rng());
+    }
+
+    pub fn deal(&mut self, players: &[&str], count: usize) -> Vec<Hand<T>> {
+        // create hands for the players
+        let mut hands: Vec<Hand<T>> = players.iter().map(|name| Hand::<T>::new(name)).collect();
+        // deal `count` cards to each `Hand`
+        for _ in 0..count {
+            for hand in &mut hands {
+                if let Some(card) = self.take_card() {
+                    hand.add_card(card);
+                }
+            }
+        }
+        // return the `Hand` list
+        hands
+    }
+}
+impl<T: CardFaces> CardCollection for Deck<T> {
+    fn size(&self) -> usize {
+        self.cards.len()
+    }
+
+    fn show_faces(&mut self) {
+        for ref mut card in &mut self.cards {
+            card.face_up = true;
+        }
+    }
+
+    fn show_backs(&mut self) {
+        for ref mut card in &mut self.cards {
+            card.face_up = false;
+        }
+    }
+}
+impl<T: CardFaces> TakeCard<T> for Deck<T> {
+    fn take_card(&mut self) -> Option<Card<T>> {
+        self.cards.pop()
+    }
+
+    fn take_match(&mut self, search_card: &Card<T>) -> Option<Card<T>> {
+        let idx = self
+            .cards
+            .iter()
+            .position(|c| c.faces.matches(&search_card.faces));
+        if let Some(i) = idx {
+            Some(self.cards.remove(i))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct StubFaces {
+        id: u8,
+    }
+
+    impl CardFaces for StubFaces {
+        fn display_front(&self) -> String {
+            format!("front-{}", self.id)
+        }
+
+        fn display_back(&self) -> Option<String> {
+            None
+        }
+
+        fn matches(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+
+        fn compare(&self, other: &Self) -> std::cmp::Ordering {
+            self.id.cmp(&other.id)
+        }
+    }
+
+    fn make_card(id: u8) -> Card<StubFaces> {
+        Card::new_card(StubFaces { id })
+    }
+
+    #[test]
+    fn new_from_faces_builds_deck_with_expected_cards() {
+        let faces = vec![StubFaces { id: 1 }, StubFaces { id: 2 }];
+
+        let deck = Deck::new_from_faces("test", &faces);
+
+        assert_eq!(deck.name, "test");
+        let ids: Vec<u8> = deck.cards.iter().map(|c| c.faces.id).collect();
+        assert_eq!(ids, vec![1, 2]);
+        // ensure original faces untouched
+        assert_eq!(faces[0].id, 1);
+    }
+
+    #[test]
+    fn take_card_removes_last_card() {
+        let mut deck = Deck::new("test", vec![make_card(1), make_card(2)]);
+
+        let taken = deck.take_card().unwrap();
+
+        assert_eq!(taken.faces.id, 2);
+        assert_eq!(deck.cards.len(), 1);
+    }
+
+    #[test]
+    fn take_match_removes_matching_card() {
+        let mut deck = Deck::new("test", vec![make_card(1), make_card(2), make_card(3)]);
+        let search = Card::new_card(StubFaces { id: 2 });
+
+        let taken = deck.take_match(&search).expect("card should be found");
+
+        assert_eq!(taken.faces.id, 2);
+        let remaining: Vec<u8> = deck.cards.iter().map(|c| c.faces.id).collect();
+        assert_eq!(remaining, vec![1, 3]);
+    }
+
+    #[test]
+    fn deal_distributes_cards_round_robin() {
+        let cards = vec![
+            make_card(1),
+            make_card(2),
+            make_card(3),
+            make_card(4),
+            make_card(5),
+            make_card(6),
+        ];
+        let mut deck = Deck::new("test", cards);
+        let players = vec!["alice", "bob"];
+
+        let hands = deck.deal(&players, 2);
+
+        assert_eq!(hands.len(), 2);
+        assert_eq!(hands[0].player, "alice");
+        assert_eq!(hands[1].player, "bob");
+        let alice_ids: Vec<u8> = hands[0].cards.iter().map(|c| c.faces.id).collect();
+        let bob_ids: Vec<u8> = hands[1].cards.iter().map(|c| c.faces.id).collect();
+        assert_eq!(alice_ids, vec![6, 4]);
+        assert_eq!(bob_ids, vec![5, 3]);
+        let deck_ids: Vec<u8> = deck.cards.iter().map(|c| c.faces.id).collect();
+        assert_eq!(deck_ids, vec![1, 2]);
+    }
+
+    #[test]
+    fn deal_gracefully_handles_insufficient_cards() {
+        let cards = vec![make_card(1), make_card(2), make_card(3)];
+        let mut deck = Deck::new("test", cards);
+        let players = vec!["a", "b"];
+
+        let hands = deck.deal(&players, 2);
+
+        let lengths: Vec<usize> = hands.iter().map(|hand| hand.cards.len()).collect();
+        assert_eq!(lengths, vec![2, 1]);
+        assert!(deck.cards.is_empty());
+    }
+}

--- a/src/cards/deck.rs
+++ b/src/cards/deck.rs
@@ -9,7 +9,11 @@
 use crate::cards::{AddCard, Card, CardCollection, CardFaces, Hand, TakeCard};
 use rand::prelude::*;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Deck<T: CardFaces> {
     pub name: String,
     pub cards: Vec<Card<T>>,

--- a/src/cards/hand.rs
+++ b/src/cards/hand.rs
@@ -1,0 +1,135 @@
+//! hand module
+//!
+//! A `Hand` of `Card<T>`
+//!
+
+use crate::cards::{AddCard, Card, CardCollection, CardFaces, TakeCard};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Hand<T: CardFaces> {
+    pub player: String,
+    pub cards: Vec<Card<T>>,
+}
+
+impl<T: CardFaces> CardCollection for Hand<T> {
+    fn size(&self) -> usize {
+        self.cards.len()
+    }
+
+    fn show_faces(&mut self) {
+        for ref mut card in &mut self.cards {
+            card.face_up = true;
+        }
+    }
+
+    fn show_backs(&mut self) {
+        for ref mut card in &mut self.cards {
+            card.face_up = false;
+        }
+    }
+}
+
+impl<T: CardFaces> Hand<T> {
+    pub fn new(player: &str) -> Self {
+        Self {
+            player: player.to_string(),
+            cards: Vec::<Card<T>>::new(),
+        }
+    }
+}
+
+impl<T: CardFaces> AddCard<T> for Hand<T> {
+    fn add_card(&mut self, card: Card<T>) {
+        self.cards.push(card);
+    }
+}
+
+impl<T: CardFaces> TakeCard<T> for Hand<T> {
+    fn take_card(&mut self) -> Option<Card<T>> {
+        self.cards.pop()
+    }
+
+    fn take_match(&mut self, search_card: &Card<T>) -> Option<Card<T>> {
+        let idx = self
+            .cards
+            .iter()
+            .position(|c| c.faces.matches(&search_card.faces));
+        if let Some(i) = idx {
+            Some(self.cards.remove(i))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct StubFaces {
+        id: u8,
+    }
+
+    impl CardFaces for StubFaces {
+        fn display_front(&self) -> String {
+            format!("front-{}", self.id)
+        }
+        fn display_back(&self) -> Option<String> {
+            None
+        }
+        fn matches(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+        fn compare(&self, other: &Self) -> std::cmp::Ordering {
+            self.id.cmp(&other.id)
+        }
+    }
+
+    fn make_card(id: u8) -> Card<StubFaces> {
+        Card::new_card(StubFaces { id })
+    }
+
+    #[test]
+    fn new_creates_empty_hand_for_player() {
+        let hand = Hand::<StubFaces>::new("bob");
+
+        assert_eq!(hand.player, "bob");
+        assert!(hand.cards.is_empty());
+    }
+
+    #[test]
+    fn add_card_pushes_to_hand() {
+        let mut hand = Hand::<StubFaces>::new("bob");
+        hand.add_card(make_card(1));
+
+        assert_eq!(hand.cards.len(), 1);
+        assert_eq!(hand.cards[0].faces.id, 1);
+    }
+
+    #[test]
+    fn take_card_returns_last_card_added() {
+        let mut hand = Hand::<StubFaces>::new("bob");
+        hand.add_card(make_card(1));
+        hand.add_card(make_card(2));
+
+        assert_eq!(hand.take_card().unwrap().faces.id, 2);
+        assert_eq!(hand.take_card().unwrap().faces.id, 1);
+        assert!(hand.take_card().is_none());
+    }
+
+    #[test]
+    fn take_match_removes_matching_card() {
+        let mut hand = Hand::<StubFaces>::new("bob");
+        hand.add_card(make_card(1));
+        hand.add_card(make_card(2));
+        hand.add_card(make_card(3));
+        let search = Card::new_card(StubFaces { id: 2 });
+
+        let taken = hand.take_match(&search).expect("card should be removed");
+
+        assert_eq!(taken.faces.id, 2);
+        let ids: Vec<u8> = hand.cards.iter().map(|c| c.faces.id).collect();
+        assert_eq!(ids, vec![1, 3]);
+    }
+}

--- a/src/cards/hand.rs
+++ b/src/cards/hand.rs
@@ -1,7 +1,29 @@
-//! hand module
+//! # Hands
 //!
-//! A `Hand` of `Card<T>`
+//! A [`Hand`] represents the cards held by a single player. Hands implement
+//! [`CardCollection`], [`AddCard`], and [`TakeCard`] so they slot into the same
+//! helper routines as decks and piles.
 //!
+//! ```
+//! use gametools::{AddCard, Card, CardCollection, CardFaces, Hand, TakeCard};
+//!
+//! #[derive(Clone)]
+//! struct Face(u8);
+//!
+//! impl CardFaces for Face {
+//!     fn display_front(&self) -> String { format!("{}", self.0) }
+//!     fn display_back(&self) -> Option<String> { None }
+//!     fn matches(&self, other: &Self) -> bool { self.0 == other.0 }
+//!     fn compare(&self, other: &Self) -> std::cmp::Ordering { self.0.cmp(&other.0) }
+//! }
+//!
+//! let mut hand = Hand::<Face>::new("alice");
+//! hand.add_card(Card::new_card(Face(7)));
+//! hand.add_card(Card::new_card(Face(3)));
+//! assert_eq!(hand.size(), 2);
+//! let top = hand.take_card().unwrap();
+//! assert_eq!(top.faces.0, 3);
+//! ```
 use crate::cards::{AddCard, Card, CardCollection, CardFaces, TakeCard};
 
 #[cfg(feature = "serde")]
@@ -9,9 +31,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+/// Cards held by a single player.
 pub struct Hand<T: CardFaces> {
+    /// Player identifier or display name.
     pub player: String,
-    pub cards: Vec<Card<T>>,
+    /// Cards currently in the player's hand. The last card is considered the "top".
+   pub cards: Vec<Card<T>>,
 }
 
 impl<T: CardFaces> CardCollection for Hand<T> {
@@ -33,6 +58,27 @@ impl<T: CardFaces> CardCollection for Hand<T> {
 }
 
 impl<T: CardFaces> Hand<T> {
+    /// Create an empty hand for the supplied `player`.
+    ///
+    /// ```
+    /// use gametools::{CardFaces, Hand};
+    ///
+    /// #[derive(Clone)]
+    /// struct Face;
+    ///
+    /// impl CardFaces for Face {
+    ///     fn display_front(&self) -> String { String::from("X") }
+    ///     fn display_back(&self) -> Option<String> { None }
+    ///     fn matches(&self, _other: &Self) -> bool { true }
+    ///     fn compare(&self, _other: &Self) -> std::cmp::Ordering {
+    ///         std::cmp::Ordering::Equal
+    ///     }
+    /// }
+    ///
+    /// let hand = Hand::<Face>::new("player");
+    /// assert_eq!(hand.player, "player");
+    /// assert_eq!(hand.cards.len(), 0);
+    /// ```
     pub fn new(player: &str) -> Self {
         Self {
             player: player.to_string(),
@@ -42,16 +88,19 @@ impl<T: CardFaces> Hand<T> {
 }
 
 impl<T: CardFaces> AddCard<T> for Hand<T> {
+    /// Add a card to the end (top) of the hand.
     fn add_card(&mut self, card: Card<T>) {
         self.cards.push(card);
     }
 }
 
 impl<T: CardFaces> TakeCard<T> for Hand<T> {
+    /// Remove and return the most recently added card, if any remain.
     fn take_card(&mut self) -> Option<Card<T>> {
         self.cards.pop()
     }
 
+    /// Remove the first card that matches the provided `search_card`.
     fn take_match(&mut self, search_card: &Card<T>) -> Option<Card<T>> {
         let idx = self
             .cards

--- a/src/cards/hand.rs
+++ b/src/cards/hand.rs
@@ -2,10 +2,13 @@
 //!
 //! A `Hand` of `Card<T>`
 //!
-
 use crate::cards::{AddCard, Card, CardCollection, CardFaces, TakeCard};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Hand<T: CardFaces> {
     pub player: String,
     pub cards: Vec<Card<T>>,

--- a/src/cards/pile.rs
+++ b/src/cards/pile.rs
@@ -1,0 +1,135 @@
+//! # Pile
+//!
+//! A pile is a named stack of cards that starts empty and can have cards added
+//! to or removed from it.
+use crate::cards::{AddCard, Card, CardCollection, CardFaces, TakeCard};
+
+pub struct Pile<T: CardFaces> {
+    pub name: String,
+    pub cards: Vec<Card<T>>,
+}
+impl<T: CardFaces> CardCollection for Pile<T> {
+    fn size(&self) -> usize {
+        self.cards.len()
+    }
+
+    fn show_faces(&mut self) {
+        for ref mut card in &mut self.cards {
+            card.face_up = true;
+        }
+    }
+
+    fn show_backs(&mut self) {
+        for ref mut card in &mut self.cards {
+            card.face_up = false;
+        }
+    }
+}
+
+impl<T: CardFaces> Pile<T> {
+    pub fn new_pile(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            cards: Vec::<Card<T>>::new(),
+        }
+    }
+}
+
+impl<T: CardFaces> AddCard<T> for Pile<T> {
+    fn add_card(&mut self, card: Card<T>) {
+        self.cards.push(card);
+    }
+}
+
+impl<T: CardFaces> TakeCard<T> for Pile<T> {
+    fn take_card(&mut self) -> Option<Card<T>> {
+        self.cards.pop()
+    }
+
+    fn take_match(&mut self, search_card: &Card<T>) -> Option<Card<T>> {
+        let idx = self
+            .cards
+            .iter()
+            .position(|c| c.faces.matches(&search_card.faces));
+        if let Some(i) = idx {
+            Some(self.cards.remove(i))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct StubFaces {
+        id: u8,
+    }
+
+    impl CardFaces for StubFaces {
+        fn display_front(&self) -> String {
+            format!("front-{}", self.id)
+        }
+
+        fn display_back(&self) -> Option<String> {
+            Some(format!("back-{}", self.id))
+        }
+
+        fn matches(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+
+        fn compare(&self, other: &Self) -> std::cmp::Ordering {
+            self.id.cmp(&other.id)
+        }
+    }
+
+    fn make_card(id: u8) -> Card<StubFaces> {
+        Card::new_card(StubFaces { id })
+    }
+
+    #[test]
+    fn new_pile_starts_empty() {
+        let pile = Pile::<StubFaces>::new_pile("discard");
+
+        assert_eq!(pile.name, "discard");
+        assert!(pile.cards.is_empty());
+    }
+
+    #[test]
+    fn add_card_appends_to_pile() {
+        let mut pile = Pile::<StubFaces>::new_pile("discard");
+        pile.add_card(make_card(10));
+
+        assert_eq!(pile.cards.len(), 1);
+        assert_eq!(pile.cards[0].faces.id, 10);
+    }
+
+    #[test]
+    fn take_card_returns_last_card_added() {
+        let mut pile = Pile::<StubFaces>::new_pile("discard");
+        pile.add_card(make_card(1));
+        pile.add_card(make_card(2));
+
+        assert_eq!(pile.take_card().unwrap().faces.id, 2);
+        assert_eq!(pile.take_card().unwrap().faces.id, 1);
+        assert!(pile.take_card().is_none());
+    }
+
+    #[test]
+    fn take_match_removes_matching_card() {
+        let mut pile = Pile::<StubFaces>::new_pile("discard");
+        pile.add_card(make_card(1));
+        pile.add_card(make_card(2));
+        pile.add_card(make_card(3));
+        let search = Card::new_card(StubFaces { id: 2 });
+
+        let taken = pile.take_match(&search).expect("card should exist");
+
+        assert_eq!(taken.faces.id, 2);
+        let ids: Vec<u8> = pile.cards.iter().map(|c| c.faces.id).collect();
+        assert_eq!(ids, vec![1, 3]);
+    }
+}

--- a/src/cards/pile.rs
+++ b/src/cards/pile.rs
@@ -4,6 +4,11 @@
 //! to or removed from it.
 use crate::cards::{AddCard, Card, CardCollection, CardFaces, TakeCard};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Pile<T: CardFaces> {
     pub name: String,
     pub cards: Vec<Card<T>>,

--- a/src/cards/std_playing_cards.rs
+++ b/src/cards/std_playing_cards.rs
@@ -1,0 +1,563 @@
+//! # Standard Playing Card
+//!
+//! This defines a standard playing card, with ranks and suits, for use with the cards module.
+//! Also included are method implementations for Hand and Deck specific to standard rank/suit cards.
+use crate::cards::{Card, CardFaces, Hand};
+use std::collections::BTreeMap;
+
+/// A standard playing card that you'd find in a typical deck of 52 (54 with Jokers).
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "camelCase"))]
+pub struct StandardCard {
+    pub suit: Suit,
+    pub rank: Rank,
+    pub value: u8,
+}
+impl StandardCard {
+    pub fn new_card(rank: Rank, suit: Suit) -> Self {
+        Self {
+            rank,
+            suit,
+            value: rank as u8,
+        }
+    }
+}
+impl CardFaces for StandardCard {
+    fn display_front(&self) -> String {
+        format!("{}.{}", self.rank, self.suit)
+    }
+
+    fn display_back(&self) -> Option<String> {
+        None
+    }
+
+    fn matches(&self, other: &Self) -> bool {
+        self.rank == other.rank && self.suit == other.suit
+    }
+
+    fn compare(&self, other: &Self) -> std::cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+/// Ranks for "normal" cards (Jokers treated separately).
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Rank {
+    Two = 2,
+    Three,
+    Four,
+    Five,
+    Six,
+    Seven,
+    Eight,
+    Nine,
+    Ten,
+    Jack,
+    Queen,
+    King,
+    Ace,
+    Joker = 255,
+}
+impl std::fmt::Display for Rank {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Rank::Two => write!(f, "2"),
+            Rank::Three => write!(f, "3"),
+            Rank::Four => write!(f, "4"),
+            Rank::Five => write!(f, "5"),
+            Rank::Six => write!(f, "6"),
+            Rank::Seven => write!(f, "7"),
+            Rank::Eight => write!(f, "8"),
+            Rank::Nine => write!(f, "9"),
+            Rank::Ten => write!(f, "10"),
+            Rank::Jack => write!(f, "J"),
+            Rank::Queen => write!(f, "Q"),
+            Rank::King => write!(f, "K"),
+            Rank::Ace => write!(f, "A"),
+            Rank::Joker => write!(f, "*"),
+        }
+    }
+}
+impl Rank {
+    /// Returns a list of the standard ranks (no Joker)
+    pub fn normal_ranks() -> Vec<Rank> {
+        vec![
+            Rank::Two,
+            Rank::Three,
+            Rank::Four,
+            Rank::Five,
+            Rank::Six,
+            Rank::Seven,
+            Rank::Eight,
+            Rank::Nine,
+            Rank::Ten,
+            Rank::Jack,
+            Rank::Queen,
+            Rank::King,
+            Rank::Ace,
+        ]
+    }
+    /// Returns a list of all ranks (Joker included)
+    pub fn all_ranks() -> Vec<Rank> {
+        let mut all_ranks = Rank::normal_ranks();
+        all_ranks.push(Rank::Joker);
+        all_ranks
+    }
+
+    pub fn from_value(value: u8) -> Option<Rank> {
+        match value {
+            1 | 14 => Some(Rank::Ace),
+            2 => Some(Rank::Two),
+            3 => Some(Rank::Three),
+            4 => Some(Rank::Four),
+            5 => Some(Rank::Five),
+            6 => Some(Rank::Six),
+            7 => Some(Rank::Seven),
+            8 => Some(Rank::Eight),
+            9 => Some(Rank::Nine),
+            10 => Some(Rank::Ten),
+            11 => Some(Rank::Jack),
+            12 => Some(Rank::Queen),
+            13 => Some(Rank::King),
+            _ => None,
+        }
+    }
+}
+
+/// Suits for "normal" playing cards (Jokers excluded.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Suit {
+    Clubs,
+    Hearts,
+    Diamonds,
+    Spades,
+    Wild,
+}
+impl std::fmt::Display for Suit {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Suit::Clubs => write!(f, "♣"),
+            Suit::Hearts => write!(f, "♥"),
+            Suit::Diamonds => write!(f, "♦"),
+            Suit::Spades => write!(f, "♠"),
+            Suit::Wild => write!(f, "?"),
+        }
+    }
+}
+impl Suit {
+    /// Returns a list of normal suits (Wild excluded).
+    pub fn normal_suits() -> Vec<Suit> {
+        vec![Suit::Clubs, Suit::Hearts, Suit::Diamonds, Suit::Spades]
+    }
+    /// Returns a list of all suits (including Wild).
+    pub fn all_suits() -> Vec<Suit> {
+        let mut all_suits = Suit::normal_suits();
+        all_suits.push(Suit::Wild);
+        all_suits
+    }
+}
+
+/// Create all 52 cards for a stanard deck.
+pub fn full_deck() -> Vec<StandardCard> {
+    let mut deck = Vec::new();
+    for suit in Suit::normal_suits() {
+        for rank in Rank::normal_ranks() {
+            deck.push(StandardCard::new_card(rank, suit));
+        }
+    }
+    deck
+}
+
+/// Create all 52 cards for a standard deck, plus two Jokers.
+pub fn full_deck_with_jokers() -> Vec<StandardCard> {
+    let mut deck = full_deck();
+    deck.push(StandardCard::new_card(Rank::Joker, Suit::Wild));
+    deck.push(StandardCard::new_card(Rank::Joker, Suit::Wild));
+    deck
+}
+
+impl Hand<StandardCard> {
+    /// Check whether a card matching a rank and suit is in the `Hand`.
+    pub fn contains(&self, rank: Rank, suit: Suit) -> bool {
+        let search = StandardCard::new_card(rank, suit);
+        self.cards.iter().any(|card| card.faces.matches(&search))
+    }
+
+    /// Count how many cards in the hand have a specific rank.
+    pub fn count_rank(&self, rank: Rank) -> usize {
+        self.cards.iter().filter(|c| c.faces.rank == rank).count()
+    }
+
+    /// Create a map of `Rank` counts for the current `Hand`.
+    pub fn rank_map(&self) -> BTreeMap<Rank, usize> {
+        let mut rank_map = BTreeMap::new();
+        for card in &self.cards {
+            rank_map
+                .entry(card.faces.rank)
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+        }
+        rank_map
+    }
+
+    /// Count how many cards in the hand have a specific suit.
+    pub fn count_suit(&self, suit: Suit) -> usize {
+        self.cards.iter().filter(|c| c.faces.suit == suit).count()
+    }
+
+    /// Create a map of `Suit` counts for the current `Hand`.
+    pub fn suit_map(&self) -> BTreeMap<Suit, usize> {
+        let mut suit_map = BTreeMap::new();
+        for card in &self.cards {
+            suit_map
+                .entry(card.faces.suit)
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+        }
+        suit_map
+    }
+
+    /// Returns true if every card in the hand belongs to the same `Suit`.
+    pub fn is_flush(&self) -> bool {
+        let total_cards = self.cards.len();
+        if total_cards == 0 {
+            return false;
+        }
+
+        let mut suit_map = self.suit_map();
+        let wildcards = suit_map.remove(&Suit::Wild).unwrap_or(0);
+
+        if suit_map.is_empty() {
+            return wildcards >= total_cards;
+        }
+
+        suit_map
+            .values()
+            .any(|count| *count + wildcards >= total_cards)
+    }
+
+    /// Check for N cards of a kind.
+    ///
+    /// Returns `None` if none reach N, or `Some` cards if there are any.
+    pub fn find_n_of_a_kind(&self, count: usize) -> Option<Vec<&StandardCard>> {
+        if count == 0 {
+            return Some(Vec::new());
+        }
+        if self.cards.len() < count {
+            return None;
+        }
+
+        let mut rank_groups: BTreeMap<Rank, Vec<&Card<StandardCard>>> = BTreeMap::new();
+        for card in &self.cards {
+            rank_groups.entry(card.faces.rank).or_default().push(card);
+        }
+
+        let jokers = rank_groups.remove(&Rank::Joker).unwrap_or_default();
+        let mut groups: Vec<(Rank, Vec<&Card<StandardCard>>)> = rank_groups.into_iter().collect();
+        groups.sort_by(|a, b| b.1.len().cmp(&a.1.len()).then_with(|| a.0.cmp(&b.0)));
+
+        for (_rank, cards) in groups {
+            let mut result: Vec<&StandardCard> =
+                cards.iter().take(count).map(|card| &card.faces).collect();
+            if result.len() == count {
+                return Some(result);
+            }
+
+            let missing = count - result.len();
+            if !jokers.is_empty() && jokers.len() >= missing {
+                result.extend(jokers.iter().take(missing).map(|card| &card.faces));
+                return Some(result);
+            }
+        }
+
+        if jokers.len() >= count {
+            return Some(jokers.iter().take(count).map(|card| &card.faces).collect());
+        }
+
+        None
+    }
+
+    /// Returns `Some` ordered cards that form a straight of the requested length, or `None` if no straight exists.
+    ///
+    /// Jokers serve as wild cards and may fill any missing rank. Aces may be used high or low.
+    pub fn find_n_straight(&self, count: usize) -> Option<Vec<&StandardCard>> {
+        // handle edge cases with obvious results
+        if count == 0 {
+            return Some(Vec::new());
+        }
+        if self.cards.len() < count || count > 14 {
+            return None;
+        }
+
+        // group cards according their ranks
+        let mut rank_groups: BTreeMap<Rank, Vec<&Card<StandardCard>>> = BTreeMap::new();
+        for card in &self.cards {
+            rank_groups.entry(card.faces.rank).or_default().push(card);
+        }
+
+        // pull the wildcards out of the rank groups, counting them for later insertion if
+        // needed to complete a straight
+        let jokers = rank_groups.remove(&Rank::Joker).unwrap_or_default();
+
+        // if all of the cards were wild, we have a straight if we have enough cards
+        if rank_groups.is_empty() {
+            return (jokers.len() >= count)
+                .then(|| jokers.iter().take(count).map(|card| &card.faces).collect());
+        }
+
+        // any sequence starting after this will run out of ranks before we have enough
+        let max_start = 14usize.saturating_sub(count).saturating_add(1);
+
+        // try to pull a card from `count` consecutive rank groups, inserting Jokers
+        // as needed and if available
+        for start in 1..=max_start {
+            let mut available = rank_groups.clone();
+            let mut jokers_left = jokers.clone();
+            let mut straight_cards: Vec<&Card<StandardCard>> = Vec::with_capacity(count);
+            let mut success = true;
+
+            for offset in 0..count {
+                let value = (start + offset) as u8;
+                let Some(rank) = Rank::from_value(value) else {
+                    success = false;
+                    break;
+                };
+
+                // if there's a natural card to fill this rank slot, use it and move on
+                if let Some(cards) = available.get_mut(&rank) {
+                    if let Some(card) = cards.pop() {
+                        straight_cards.push(card);
+                        continue;
+                    }
+                }
+
+                // if there's Joker to fill this rank slot, use it and move on
+                if let Some(joker_card) = jokers_left.pop() {
+                    straight_cards.push(joker_card);
+                } else {
+                    success = false;
+                    break;
+                }
+            }
+
+            if success {
+                let straight_faces = straight_cards.iter().map(|card| &card.faces).collect();
+                return Some(straight_faces);
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cards::Card;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn standard_card_constructor_sets_rank_suit_and_value() {
+        let card = StandardCard::new_card(Rank::Ace, Suit::Spades);
+
+        assert_eq!(card.rank, Rank::Ace);
+        assert_eq!(card.suit, Suit::Spades);
+        assert_eq!(card.value, Rank::Ace as u8);
+    }
+
+    #[test]
+    fn standard_card_display_and_faces_behave_as_expected() {
+        let card = StandardCard::new_card(Rank::Ten, Suit::Hearts);
+
+        assert_eq!(card.display_front(), "10.♥");
+        assert!(card.display_back().is_none());
+    }
+
+    #[test]
+    fn matches_and_compare_follow_rank_and_suit() {
+        let low = StandardCard::new_card(Rank::Five, Suit::Clubs);
+        let high = StandardCard::new_card(Rank::Seven, Suit::Clubs);
+        let different_suit = StandardCard::new_card(Rank::Five, Suit::Hearts);
+
+        assert!(low.matches(&StandardCard::new_card(Rank::Five, Suit::Clubs)));
+        assert!(!low.matches(&different_suit));
+        assert_eq!(low.compare(&high), std::cmp::Ordering::Less);
+        assert_eq!(high.compare(&low), std::cmp::Ordering::Greater);
+        assert_eq!(low.compare(&low), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn normal_ranks_and_suits_return_expected_sets() {
+        let ranks = Rank::normal_ranks();
+        let suits = Suit::normal_suits();
+
+        assert_eq!(ranks.len(), 13);
+        assert!(ranks.iter().all(|rank| *rank != Rank::Joker));
+        assert_eq!(suits.len(), 4);
+        assert!(!suits.contains(&Suit::Wild));
+    }
+
+    #[test]
+    fn full_deck_contains_all_rank_suit_combinations() {
+        let deck = full_deck();
+
+        assert_eq!(deck.len(), 52);
+        let unique: BTreeSet<(Rank, Suit)> = deck.iter().map(|c| (c.rank, c.suit)).collect();
+        assert_eq!(unique.len(), 52);
+    }
+
+    #[test]
+    fn full_deck_with_jokers_adds_two_wild_cards() {
+        let deck = full_deck_with_jokers();
+
+        assert_eq!(deck.len(), 54);
+        let joker_count = deck
+            .iter()
+            .filter(|c| c.rank == Rank::Joker && c.suit == Suit::Wild)
+            .count();
+        assert_eq!(joker_count, 2);
+    }
+
+    #[test]
+    fn hand_detects_ace_low_straight() {
+        let mut hand = Hand::new("player");
+        let cards = [
+            (Rank::Ace, Suit::Spades),
+            (Rank::Two, Suit::Clubs),
+            (Rank::Three, Suit::Diamonds),
+            (Rank::Four, Suit::Hearts),
+            (Rank::Five, Suit::Spades),
+        ];
+
+        for (rank, suit) in cards {
+            hand.cards
+                .push(Card::new_card(StandardCard::new_card(rank, suit)));
+        }
+
+        let straight = hand.find_n_straight(5).expect("expected ace-low straight");
+        let ranks: Vec<Rank> = straight.iter().map(|card| card.rank).collect();
+        assert_eq!(
+            ranks,
+            vec![Rank::Ace, Rank::Two, Rank::Three, Rank::Four, Rank::Five]
+        );
+    }
+
+    #[test]
+    fn hand_detects_straight_with_joker() {
+        let mut hand = Hand::new("player");
+        let cards = [
+            (Rank::Ten, Suit::Hearts),
+            (Rank::Queen, Suit::Diamonds),
+            (Rank::King, Suit::Clubs),
+            (Rank::Ace, Suit::Spades),
+        ];
+
+        for (rank, suit) in cards {
+            hand.cards
+                .push(Card::new_card(StandardCard::new_card(rank, suit)));
+        }
+        hand.cards.push(Card::new_card(StandardCard::new_card(
+            Rank::Joker,
+            Suit::Wild,
+        )));
+
+        let straight = hand
+            .find_n_straight(5)
+            .expect("expected straight with joker");
+        assert_eq!(straight.len(), 5);
+        assert_eq!(
+            straight
+                .iter()
+                .filter(|card| card.rank == Rank::Joker)
+                .count(),
+            1
+        );
+        let mut ranks: Vec<_> = straight.iter().map(|card| card.rank).collect();
+        ranks.sort();
+        assert!(ranks.contains(&Rank::Ten));
+        assert!(ranks.contains(&Rank::Queen));
+        assert!(ranks.contains(&Rank::King));
+        assert!(ranks.contains(&Rank::Ace));
+    }
+
+    #[test]
+    fn hand_requires_enough_jokers_to_fill_gaps() {
+        let mut hand = Hand::new("player");
+        let cards = [
+            (Rank::Two, Suit::Diamonds),
+            (Rank::Four, Suit::Clubs),
+            (Rank::Six, Suit::Spades),
+        ];
+        for (rank, suit) in cards {
+            hand.cards
+                .push(Card::new_card(StandardCard::new_card(rank, suit)));
+        }
+        hand.cards.push(Card::new_card(StandardCard::new_card(
+            Rank::Joker,
+            Suit::Wild,
+        )));
+
+        assert!(hand.find_n_straight(4).is_none());
+    }
+
+    #[test]
+    fn hand_finds_three_of_a_kind_using_joker() {
+        let mut hand = Hand::new("player");
+        let cards = [
+            (Rank::Ten, Suit::Hearts),
+            (Rank::Ten, Suit::Clubs),
+            (Rank::Joker, Suit::Wild),
+        ];
+        for (rank, suit) in cards {
+            hand.cards
+                .push(Card::new_card(StandardCard::new_card(rank, suit)));
+        }
+
+        let trio = hand
+            .find_n_of_a_kind(3)
+            .expect("expected three of a kind with joker support");
+        assert_eq!(trio.len(), 3);
+        assert_eq!(trio.iter().filter(|card| card.rank == Rank::Ten).count(), 2);
+        assert_eq!(
+            trio.iter().filter(|card| card.rank == Rank::Joker).count(),
+            1
+        );
+    }
+
+    #[test]
+    fn hand_allows_flush_with_joker() {
+        let mut hand = Hand::new("player");
+        let cards = [
+            (Rank::Two, Suit::Hearts),
+            (Rank::Four, Suit::Hearts),
+            (Rank::Six, Suit::Hearts),
+            (Rank::Nine, Suit::Hearts),
+            (Rank::Joker, Suit::Wild),
+        ];
+        for (rank, suit) in cards {
+            hand.cards
+                .push(Card::new_card(StandardCard::new_card(rank, suit)));
+        }
+
+        assert!(hand.is_flush());
+    }
+
+    #[test]
+    fn hand_of_only_jokers_counts_as_flush_and_of_a_kind() {
+        let mut hand = Hand::new("player");
+        for _ in 0..3 {
+            hand.cards.push(Card::new_card(StandardCard::new_card(
+                Rank::Joker,
+                Suit::Wild,
+            )));
+        }
+
+        assert!(hand.is_flush());
+        let wild_trio = hand
+            .find_n_of_a_kind(3)
+            .expect("expected jokers to satisfy kind");
+        assert_eq!(wild_trio.len(), 3);
+        assert!(wild_trio.iter().all(|card| card.rank == Rank::Joker));
+    }
+}

--- a/src/cards/std_playing_cards.rs
+++ b/src/cards/std_playing_cards.rs
@@ -5,10 +5,12 @@
 use crate::cards::{Card, CardFaces, Hand};
 use std::collections::BTreeMap;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// A standard playing card that you'd find in a typical deck of 52 (54 with Jokers).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "camelCase"))]
 pub struct StandardCard {
     pub suit: Suit,
     pub rank: Rank,
@@ -43,6 +45,7 @@ impl CardFaces for StandardCard {
 
 /// Ranks for "normal" cards (Jokers treated separately).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Rank {
     Two = 2,
     Three,
@@ -125,8 +128,9 @@ impl Rank {
     }
 }
 
-/// Suits for "normal" playing cards (Jokers excluded.)
+/// Suits for "normal" playing cards
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Suit {
     Clubs,
     Hearts,

--- a/src/cards/std_playing_cards.rs
+++ b/src/cards/std_playing_cards.rs
@@ -1,16 +1,16 @@
 //! # Standard Playing Cards
 //!
-//! Helpers for working with the canonical 52-card deck (plus optional jokers).
-//! The [`StandardCard`] type implements [`CardFaces`](crate::cards::CardFaces) so it can be
-//! wrapped in a [`Card`](crate::cards::Card) and used with [`Deck`](crate::cards::Deck),
-//! [`Hand`](crate::cards::Hand), or [`Pile`](crate::cards::Pile).
+//! Helpers for working with the canonical 52-card deck (plus optional Jokers).
+//! The [`StandardCard`] type implements [`CardFaces`] so it can be
+//! wrapped in a [`Card`] and used with [`Deck`](crate::cards::Deck),
+//! [`Hand`], or [`Pile`](crate::cards::Pile).
 //!
 //! ```
 //! use gametools::{Card, CardCollection, Deck};
 //! use gametools::cards::std_playing_cards::{full_deck, Rank, StandardCard, Suit};
 //!
 //! // Create a full deck and wrap each face in a Card.
-//! let cards = full_deck()
+//! let cards = full_deck()     // or full_deck_with_jokers() for added 2 Jokers / wildcards
 //!     .into_iter()
 //!     .map(Card::new_card)
 //!     .collect::<Vec<_>>();
@@ -18,7 +18,7 @@
 //! let mut deck = Deck::new("standard", cards);
 //! assert_eq!(deck.size(), 52);
 //!
-//! // Peek at the display formatting for a single card.
+//! // Create an individual card by rank and suit.
 //! let ace_spades = StandardCard::new_card(Rank::Ace, Suit::Spades);
 //! assert_eq!(ace_spades.rank, Rank::Ace);
 //! assert_eq!(ace_spades.suit, Suit::Spades);

--- a/src/dice.rs
+++ b/src/dice.rs
@@ -292,7 +292,7 @@ impl DicePool {
         self.rolls.iter().filter(|&r| *r == value).count()
     }
 
-    /// Returns a hashmap of "binned" values from the dicepool, where bins[value] = # of times that value was rolled.
+    /// Returns a hashmap of "binned" values from the dicepool, where bins\[value\] = # of times that value was rolled.
     /// ```
     /// use gametools::DicePool;
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@ pub mod dice;
 pub use dice::{DicePool, Die};
 
 pub mod cards;
-pub use cards::{AddCard, Card, CardHand, Deck, Pile, Rank, Suit, TakeCard};
+pub use cards::{
+    AddCard, Card, CardCollection, CardFaces, CardHand, Deck, Hand, Pile, Rank, Suit, TakeCard,
+};
 
 pub mod dominos;
 pub use dominos::{BonePile, Domino, DominoHand, Train, MAX_PIPS};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,12 @@
 //! games and simulations.
 //!
 //! ## Features
-//! - Standard 52-card deck handling with tools for decks, piles, and hands.
+//! - Cards module that supports cards of any type, with 1 or 2 faces.
+//! - Pre-defined StandardCard type for standard playing cards.
+//! - Hand analytics for standard cards (detect straight, "n" of a kind, etc.) including Joker / wildcard handling.
 //! - Numeric dice with up to 255 sides.
-//! - Tools for playing with pools of dice.
-//! - Spinners with "wedges" returning arbitrary types and can be covered/blocked or weighted.
+//! - Tools for playing with and transforming pools of dice.
+//! - Spinners (random selectors) with "wedges" returning arbitrary types and can be covered/blocked or weighted.
 //! - Domino set creation (up to full double-18) and management.
 //! - Pathfinding with backtracking + pruning to find optimum domino train in a hand.
 //! - Custom GameResult and GameError types to help with common game conditions.


### PR DESCRIPTION
# Generic Card Handling

The `cards` module has been completely replaced and is now vastly more versatile, capable of handling any arbitrary types of cards, so long as the user can define how to display the front and back, and how the cards can be compared.

## What's Changed
- new `CardFaces` trait allows user-defined display, matching, and comparison of cards
- `Card` is no longer hard-wired to a standard playing card; replaced by `Card<T>` where `T: CardFaces`
- Standard playing cards can still be used by creating a deck of `Card<StandardCard>`

## What's Added
- separate module to define standard playing cards (`StandardCard`) for use with the main `cards` module
- some analytic functions for finding patterns in hands (rank and suit maps, straight and n_of_a_kind and flush detection)
- support for Jokers (wildcards)
- all new documentation and doctests

## Testing
-  unit tests cover major functions, may need some expansion / review
- cargo test --all passes

@codex to review



