### PR TITLE
Expand standard deck creation

### DIFF
--- a/src/cards/std_playing_cards.rs
+++ b/src/cards/std_playing_cards.rs
@@ -7,10 +7,10 @@
 //!
 //! ```
 //! use gametools::{Card, CardCollection, Deck};
-//! use gametools::cards::std_playing_cards::{full_deck, Rank, StandardCard, Suit};
+//! use gametools::cards::std_playing_cards::{standard_52, Rank, StandardCard, Suit};
 //!
 //! // Create a full deck and wrap each face in a Card.
-//! let cards = full_deck()     // or full_deck_with_jokers() for added 2 Jokers / wildcards
+//! let cards = standard_52()     // or standard_52_with_jokers() for added 2 Jokers / wildcards
 //!     .into_iter()
 //!     .map(Card::new_card)
 //!     .collect::<Vec<_>>();
@@ -288,9 +288,9 @@ impl DeckModifier for Vec<StandardCard> {
 /// Create a full 52-card deck plus two jokers.
 ///
 /// ```
-/// use gametools::cards::std_playing_cards::full_deck_2_jokers;
+/// use gametools::cards::std_playing_cards::standard_52_with_jokers;
 ///
-/// let deck = full_deck_2_jokers();
+/// let deck = standard_52_with_jokers();
 /// assert_eq!(deck.len(), 54);
 /// ```
 pub fn standard_52_with_jokers() -> Vec<StandardCard> {

--- a/src/cards/std_playing_cards.rs
+++ b/src/cards/std_playing_cards.rs
@@ -245,7 +245,7 @@ pub fn full_deck() -> Vec<StandardCard> {
     deck
 }
 
-/// Add Jokers to an existing `Deck`
+/// Trait to add Joker-adding behavior to a StandardCard vector.
 ///
 /// Varying rules for common card games may include anywhere from 0-4 Jokers, so sometimes
 /// the most common configuration of 52 + 2J (as built by `full_deck_2_jokers()`) isn't
@@ -318,6 +318,7 @@ pub fn euchre_deck() -> Vec<StandardCard> {
         .collect();
     deck
 }
+
 impl Hand<StandardCard> {
     /// Check whether a card matching a rank and suit is in the `Hand`.
     ///
@@ -548,6 +549,27 @@ mod tests {
                 | Rank::King
                 | Rank::Ace
         )));
+    }
+
+    #[test]
+    fn add_jokers_adds_expected_cards() {
+        let joker_deck: Vec<StandardCard> = Vec::new().add_jokers(10);
+        assert_eq!(joker_deck.len(), 10);
+
+        let full_plus_four: Vec<StandardCard> = full_deck().add_jokers(4);
+        assert_eq!(full_plus_four.len(), 52 + 4);
+
+        let wild_count = full_plus_four
+            .iter()
+            .filter(|c| c.suit == Suit::Wild)
+            .count();
+        assert_eq!(wild_count, 4);
+
+        let joker_count = full_plus_four
+            .iter()
+            .filter(|c| c.rank == Rank::Joker)
+            .count();
+        assert_eq!(joker_count, 4);
     }
 
     #[test]


### PR DESCRIPTION
Within the standard playing card module (std_playing_cards.rs):
- changed `full_deck()` to `standard_52()` to avoid the implication that the function returns a `Deck<StandardCard>`, when it actually returns `Vec<StandardCard>`. 
- created an extension trait on `Vec<StandardCard>` to allow easy modification in a builder style pattern in creating a custom deck, allowing constructions like:

```rust
use gametools::cards::std_playing_cards::{standard_52, DeckModifier};

let strange_deck = standard_52().add_jokers(5).remove_ranks(&[Rank::Two, Rank::Jack]).duplicate(2);
```

- the `standard_52_with_jokers`, `piquet_deck`, and `euchre_deck` constructors now all go through `standard_52()` and deck modifiers as above

@codex review
