### PR TITLE
Ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.zed/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .zed/settings.json
+.codex

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - `Dominos` module with support for longest-path train solving
 - `Spinners` with support for weighted wedges and optional blocking
 - `RefillingPool` - a collection of any type which distributes its contents randomly and refills itself when empty; conditional draw methods make it possible to preferentially yield certain items first according to context.
+- `ordering` module containing `RankedOrder` and `PriorityQueue`: `Vec`- and `BinaryHeap`-backed structures that can hold any type and maintain the order of their elements. The type system is leveraged to allow these to work in either min-first or max-first fashion without having to manually wrap types in `Reverse` to get that behavior. `RankedOrder` is optimized for batched processing and inspection of the full order, whereas `PriorityQueue` is optimized for rapid push()/pop() cycles and situations where only the top priority element is needed.
 - 🧪 Well-documented and tested with 90%+ code coverage
 
 ## Example: Cards

--- a/examples/priority_queue/main.rs
+++ b/examples/priority_queue/main.rs
@@ -1,0 +1,56 @@
+//! # `PriorityQueue` example.
+//!
+//! Here we have a small group of ships, each as some distance from a target, and each has known speed.
+//! We'll base the attack order on how long it takes each unit to reach its target.
+use gametools::ordering::MinPriorityQ;
+
+fn main() {
+    // Since we want to prioritize units with the *lowest* time to reach their target, we want
+    // a `PriorityQueue<_,_,Min>` - but using the type alias `MinPriorityQ` is a little nicer.
+    let mut attack_order = MinPriorityQ::new();
+
+    // Build our fleet and push the units onto the heap, using time to reach target
+    // as the priority.
+    println!("Building the fleet...");
+    let attackers = build_fleet();
+    println!("Organizing the fleet...");
+    for unit in attackers {
+        let time_to_target = unit.distance / unit.speed;
+        attack_order.push(unit, time_to_target);
+    }
+
+    // Since we used a MinPriorityQ, (= PriorityQueue<_,_,Min>) we get the unit with the
+    // lowest time-to-target (ttt) in the pool with each pop(). We could add more
+    // attackers at any time mid-stream and always get the nearest (time-wise) from pop().
+    println!("Starting attack!");
+    while let Some((attacker, ttt)) = attack_order.pop() {
+        println!("    → {:<10} ({} min to target)", attacker.name, ttt);
+    }
+}
+
+// Build a small fleet of naval units with a set speed and distance to some target.
+fn build_fleet<'a>() -> Vec<NavalUnit<'a>> {
+    vec![
+        NavalUnit::from(("Fast Boat", 40, 10)),
+        NavalUnit::from(("Cruiser", 30, 5)),
+        NavalUnit::from(("Tugboat", 10, 2)),
+        NavalUnit::from(("Submarine", 48, 8)),
+    ]
+}
+
+#[derive(Debug, Clone)]
+struct NavalUnit<'a> {
+    name: &'a str,
+    distance: u64,
+    speed: u64,
+}
+
+impl<'a> From<(&'a str, u64, u64)> for NavalUnit<'a> {
+    fn from((name, distance, speed): (&'a str, u64, u64)) -> Self {
+        Self {
+            name,
+            distance,
+            speed,
+        }
+    }
+}

--- a/examples/ranked_order/main.rs
+++ b/examples/ranked_order/main.rs
@@ -1,68 +1,48 @@
 //! `RankedOrder` example.
 //!
+//! Here we're getting ready for a turn, determining turn order for a large party.
+//!
+//! The `npc_generator` module uses a bunch of `RefillingPool`s to create a party with
+//! randomized names and stats.
+//!
+//! The `initiative` closure is used to rank the characters for the turn using
+//! a `DescendingOrder` (which is a `RankedOrder<_,_,Descending>`). They then
+//! "take their turns" by popping from the order and calling their Npc::take_turn() method.
 use gametools::Die;
 use gametools::GameResult;
-use gametools::RefillingPool;
 use gametools::ordering::DescendingOrder;
 
-struct RpgCharacter {
-    name: String,
-    dex: u64,
-    encumbrance: u64,
-    modifier: Option<u64>,
-}
-impl RpgCharacter {
-    fn take_turn(&self) {
-        println!(
-            "{} (dex:{} mod:{} enc:{}) takes a turn → ",
-            self.name,
-            self.dex,
-            self.modifier.unwrap_or_default(),
-            self.encumbrance
-        );
-    }
-}
+mod npc_generator;
+use npc_generator::{Npc, NpcGenerator};
+
+const PARTY_SIZE: usize = 30;
 
 fn main() -> GameResult<()> {
-    let d20 = Die::new(20).unwrap();
-    let initiative = |npc: &RpgCharacter| {
-        (npc.dex / 5 + d20.roll() + npc.modifier.unwrap_or_default()) * 100 / npc.encumbrance
-    };
-    let militia = create_characters(30)?;
-    let mut turn_order = DescendingOrder::new();
-    for character in militia {
-        turn_order.push_with_ranker(character, initiative);
+    // Create a party of 30 characters.
+    let big_party = create_characters(PARTY_SIZE)?;
+
+    // Create a formula for determining turn order.
+    let d20 = Die::new(20)?;
+    let initiative =
+        |npc: &Npc| (npc.dexterity + npc.speed / 5 + (d20.roll()) as u32) * 100 / npc.encumbrance;
+
+    // Create a descending-ordered list of characters based on their initiative.
+    let mut initiative_order = DescendingOrder::new();
+    for character in big_party {
+        initiative_order.push_with_ranker(character, initiative);
     }
-    while let Some((npc, _)) = turn_order.pop() {
+
+    // "Take turns" by popping from the initiative order and calling Npc::take_turn().
+    println!("Init | Npc::take_turn()");
+    println!("----------------------------------");
+    while let Some((npc, initiative)) = initiative_order.pop() {
+        print!("{initiative:>3}: ");
         npc.take_turn();
     }
     Ok(())
 }
 
-fn create_characters(count: usize) -> GameResult<Vec<RpgCharacter>> {
-    let mut first_names = RefillingPool::new([
-        "Grog", "Dart", "Frood", "Stiv", "Binnt", "Urexa", "Risto", "Fanna", "Kukaa",
-    ])?;
-    let mut last_names = RefillingPool::new([
-        "Sharder",
-        "Leppre",
-        "Broilan",
-        "Measterton",
-        "Shale",
-        "Blantt",
-        "Phluphem",
-        "Queempai",
-    ])?;
-    let mut dex_values = RefillingPool::new(8..18)?;
-    let mut encumbrances = RefillingPool::new(80..120)?;
-    let mut modifiers = RefillingPool::new([Some(5), Some(3), None, None, None, None])?;
-
-    Ok((0..count)
-        .map(|_| RpgCharacter {
-            name: format!("{} {}", first_names.draw(), last_names.draw()),
-            dex: dex_values.draw(),
-            encumbrance: encumbrances.draw(),
-            modifier: modifiers.draw(),
-        })
-        .collect())
+fn create_characters(count: usize) -> GameResult<Vec<Npc>> {
+    let mut npcgen = NpcGenerator::new()?;
+    Ok((0..count).map(|_| npcgen.generate()).collect())
 }

--- a/examples/ranked_order/main.rs
+++ b/examples/ranked_order/main.rs
@@ -12,11 +12,6 @@ struct RpgCharacter {
     modifier: Option<u64>,
 }
 impl RpgCharacter {
-    fn initiative(&self, die: &Die) -> u64 {
-        // expressing encumbrance as an integer % of some max (60 = 60%, 110 = 110%) allows us to
-        // avoid casting by using a u64. Multiplying by 100/enc = dividing by enc/100.
-        (self.dex / 5 + die.roll() + self.modifier.unwrap_or_default()) * 100 / self.encumbrance
-    }
     fn take_turn(&self) {
         println!(
             "{} (dex:{} mod:{} enc:{}) takes a turn → ",
@@ -30,11 +25,13 @@ impl RpgCharacter {
 
 fn main() -> GameResult<()> {
     let d20 = Die::new(20).unwrap();
+    let initiative = |npc: &RpgCharacter| {
+        (npc.dex / 5 + d20.roll() + npc.modifier.unwrap_or_default()) * 100 / npc.encumbrance
+    };
     let militia = create_characters(30)?;
     let mut turn_order = DescendingOrder::new();
     for character in militia {
-        let initiative = character.initiative(&d20);
-        turn_order.push(character, initiative);
+        turn_order.push_with_ranker(character, initiative);
     }
     while let Some((npc, _)) = turn_order.pop() {
         npc.take_turn();

--- a/examples/ranked_order/main.rs
+++ b/examples/ranked_order/main.rs
@@ -1,0 +1,71 @@
+//! `RankedOrder` example.
+//!
+use gametools::Die;
+use gametools::GameResult;
+use gametools::RefillingPool;
+use gametools::ordering::DescendingOrder;
+
+struct RpgCharacter {
+    name: String,
+    dex: u64,
+    encumbrance: u64,
+    modifier: Option<u64>,
+}
+impl RpgCharacter {
+    fn initiative(&self, die: &Die) -> u64 {
+        // expressing encumbrance as an integer % of some max (60 = 60%, 110 = 110%) allows us to
+        // avoid casting by using a u64. Multiplying by 100/enc = dividing by enc/100.
+        (self.dex / 5 + die.roll() + self.modifier.unwrap_or_default()) * 100 / self.encumbrance
+    }
+    fn take_turn(&self) {
+        println!(
+            "{} (dex:{} mod:{} enc:{}) takes a turn → ",
+            self.name,
+            self.dex,
+            self.modifier.unwrap_or_default(),
+            self.encumbrance
+        );
+    }
+}
+
+fn main() -> GameResult<()> {
+    let d20 = Die::new(20).unwrap();
+    let militia = create_characters(30)?;
+    let mut turn_order = DescendingOrder::new();
+    for character in militia {
+        let initiative = character.initiative(&d20);
+        turn_order.push(character, initiative);
+    }
+    while let Some((npc, _)) = turn_order.pop() {
+        npc.take_turn();
+    }
+    Ok(())
+}
+
+fn create_characters(count: usize) -> GameResult<Vec<RpgCharacter>> {
+    let mut first_names = RefillingPool::new([
+        "Grog", "Dart", "Frood", "Stiv", "Binnt", "Urexa", "Risto", "Fanna", "Kukaa",
+    ])?;
+    let mut last_names = RefillingPool::new([
+        "Sharder",
+        "Leppre",
+        "Broilan",
+        "Measterton",
+        "Shale",
+        "Blantt",
+        "Phluphem",
+        "Queempai",
+    ])?;
+    let mut dex_values = RefillingPool::new(8..18)?;
+    let mut encumbrances = RefillingPool::new(80..120)?;
+    let mut modifiers = RefillingPool::new([Some(5), Some(3), None, None, None, None])?;
+
+    Ok((0..count)
+        .map(|_| RpgCharacter {
+            name: format!("{} {}", first_names.draw(), last_names.draw()),
+            dex: dex_values.draw(),
+            encumbrance: encumbrances.draw(),
+            modifier: modifiers.draw(),
+        })
+        .collect())
+}

--- a/examples/ranked_order/npc_generator.rs
+++ b/examples/ranked_order/npc_generator.rs
@@ -1,0 +1,65 @@
+use gametools::{GameResult, RefillingPool};
+
+static FIRST_NAMES: [&str; 18] = [
+    "Dave", "Chris", "Kathleen", "Andrew", "Emily", "Echo", "Pullo", "Finn", "Mary", "Peggy",
+    "Rorie", "Leland", "Penelope", "Hari", "Gaal", "Hober", "Poly", "Constant",
+];
+
+static LAST_NAMES: [&str; 9] = [
+    "Stinkfoot",
+    "Garglebottom",
+    "Grabbutt",
+    "Whoomi",
+    "Shrubber",
+    "Dornick",
+    "Seldon",
+    "Mallow",
+    "Verisof",
+];
+pub struct Npc {
+    pub(crate) name: String,
+    pub(crate) strength: u32,
+    pub(crate) dexterity: u32,
+    pub(crate) stamina: u32,
+    pub(crate) speed: u32,
+    pub(crate) encumbrance: u32,
+}
+impl Npc {
+    pub fn take_turn(&self) {
+        println!("→ {} takes a turn…", self.name)
+    }
+}
+
+pub struct NpcGenerator {
+    first_names: RefillingPool<String>,
+    last_names: RefillingPool<String>,
+    strengths: RefillingPool<u32>,
+    dexterities: RefillingPool<u32>,
+    staminas: RefillingPool<u32>,
+    speeds: RefillingPool<u32>,
+    encumbrances: RefillingPool<u32>,
+}
+impl NpcGenerator {
+    pub fn new() -> GameResult<Self> {
+        Ok(Self {
+            first_names: RefillingPool::new(FIRST_NAMES.map(|s| s.to_string()))?,
+            last_names: RefillingPool::new(LAST_NAMES.map(|s| s.to_string()))?,
+            strengths: RefillingPool::new(8..19)?,
+            dexterities: RefillingPool::new(8..19)?,
+            staminas: RefillingPool::new(40..70)?,
+            speeds: RefillingPool::new(1..5)?,
+            encumbrances: RefillingPool::new(80..110)?,
+        })
+    }
+
+    pub fn generate(&mut self) -> Npc {
+        Npc {
+            name: format!("{} {}", self.first_names.draw(), self.last_names.draw()),
+            strength: self.strengths.draw(),
+            dexterity: self.dexterities.draw(),
+            stamina: self.staminas.draw(),
+            speed: self.speeds.draw(),
+            encumbrance: self.encumbrances.draw(),
+        }
+    }
+}

--- a/examples/ranked_order/npc_generator.rs
+++ b/examples/ranked_order/npc_generator.rs
@@ -18,9 +18,7 @@ static LAST_NAMES: [&str; 9] = [
 ];
 pub struct Npc {
     pub(crate) name: String,
-    pub(crate) strength: u32,
     pub(crate) dexterity: u32,
-    pub(crate) stamina: u32,
     pub(crate) speed: u32,
     pub(crate) encumbrance: u32,
 }
@@ -33,9 +31,7 @@ impl Npc {
 pub struct NpcGenerator {
     first_names: RefillingPool<String>,
     last_names: RefillingPool<String>,
-    strengths: RefillingPool<u32>,
     dexterities: RefillingPool<u32>,
-    staminas: RefillingPool<u32>,
     speeds: RefillingPool<u32>,
     encumbrances: RefillingPool<u32>,
 }
@@ -44,9 +40,7 @@ impl NpcGenerator {
         Ok(Self {
             first_names: RefillingPool::new(FIRST_NAMES.map(|s| s.to_string()))?,
             last_names: RefillingPool::new(LAST_NAMES.map(|s| s.to_string()))?,
-            strengths: RefillingPool::new(8..19)?,
             dexterities: RefillingPool::new(8..19)?,
-            staminas: RefillingPool::new(40..70)?,
             speeds: RefillingPool::new(1..5)?,
             encumbrances: RefillingPool::new(80..110)?,
         })
@@ -55,9 +49,7 @@ impl NpcGenerator {
     pub fn generate(&mut self) -> Npc {
         Npc {
             name: format!("{} {}", self.first_names.draw(), self.last_names.draw()),
-            strength: self.strengths.draw(),
             dexterity: self.dexterities.draw(),
-            stamina: self.staminas.draw(),
             speed: self.speeds.draw(),
             encumbrance: self.encumbrances.draw(),
         }

--- a/src/gameerror.rs
+++ b/src/gameerror.rs
@@ -34,9 +34,11 @@ pub enum GameError {
     PoolCannotBeEmpty,
     #[error("invalid index {0} for pool size {1}")]
     InvalidPoolIndex(usize, usize),
+    #[error("dice error: {0}")]
+    DiceError(#[from] DiceError),
 }
 
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone, Error, PartialEq)]
 pub enum DiceError {
     #[error("a die with zero sides cannot be created")]
     DieWithNoSides,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,3 +36,9 @@ pub use spinners::{Spinner, Wedge, wedges_from_tuples, wedges_from_values};
 pub mod gameerror;
 pub use gameerror::GameError;
 pub type GameResult<T> = Result<T, GameError>;
+
+pub mod ordering;
+pub use ordering::{
+    AscendingOrder, DescendingOrder, Max, MaxPriorityQ, Min, MinPriorityQ, PriorityQueue,
+    RankedOrder,
+};

--- a/src/ordering.rs
+++ b/src/ordering.rs
@@ -1,0 +1,23 @@
+//! `ordering` - types for handling anything in a particular order.
+//!
+//! While some of these types appear to do essentially the same job, the underlying
+//! mechanics can make a difference in terms of which is best to use:
+//!
+//! ## `RankedOrder` is best when:
+//! - you need the full ranked order, not just the #1 priority
+//! - stable visible ordering (as in UI display) matters
+//! - queue sizes are small to moderate
+//! - changing priorities of items already in place may be required
+//! - high throughput is not a big concern
+//!
+//! ## `PriorityQueue` is best when:
+//! - you just need quick access to the highest ranked item in a pool
+//! - you rarely need to inspect the order beyond the element with top priority
+//! - queue sizes are large and are modified frequently
+//!
+
+pub mod ranked_order;
+pub use ranked_order::*;
+
+pub mod priority_queue;
+pub use priority_queue::*;

--- a/src/ordering/priority_queue.rs
+++ b/src/ordering/priority_queue.rs
@@ -1,0 +1,243 @@
+//! `PriorityQueue` - a collection of items that can be handled in a prioritized order.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::marker::PhantomData;
+
+pub type MaxPriorityQ<P, T> = PriorityQueue<P, T, Max>;
+pub type MinPriorityQ<P, T> = PriorityQueue<P, T, Min>;
+
+/// Type used to indicate that the `PriorityQueue` should yield the highest priority items first.
+pub struct Max;
+/// Type used to indicate that the `PriorityQueue` should yield the lowest priority items first.
+pub struct Min;
+
+/// # `PriorityQueue<P, T, O = Max>`
+///
+/// A collection that yields its items in a ranked order. If two or more items tie on
+/// priority, they are returned in the order they were inserted.
+///
+/// # Type Parameters
+/// - `P: Ord` - the type (typically numeric) of the priority values
+/// - `T` - the type of the items in the queue
+/// - `O = Max` - determines whether the `Max` (default) or `Min` items are yielded first.
+///
+/// # Aliases
+/// - `MaxPriorityQ<P, T>`: A priority queue that yields the highest priority items first.
+/// - `MinPriorityQ<P, T>`: A priority queue that yields the lowest priority items first.
+///
+/// # Examples
+///
+/// ```
+/// use gametools::ordering::priority_queue::{MaxPriorityQ, MinPriorityQ};
+///
+/// let mut max_q = MaxPriorityQ::new();
+/// let mut min_q = MinPriorityQ::new();
+///
+/// max_q.push("high", 10);
+/// max_q.push("low", 5);
+///
+/// min_q.push("high", 10);
+/// min_q.push("low", 5);
+///
+/// assert_eq!(max_q.pop(), Some(("high", 10)));
+/// assert_eq!(min_q.pop(), Some(("low", 5)));
+/// ```
+#[derive(Debug)]
+pub struct PriorityQueue<P, T, O = Max>
+where
+    P: Ord,
+{
+    heap: BinaryHeap<RankedItem<P, T, O>>,
+    seq: u64,
+}
+impl<P: Ord, T, O> PriorityQueue<P, T, O> {
+    /// Create a new, empty `PriorityQueue`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::priority_queue::{MaxPriorityQ, PriorityQueue, Min};
+    ///
+    /// let mut q_high_first = MaxPriorityQ::new();
+    /// q_high_first.push("foo", 1);
+    ///
+    /// // or more verbose / explicit
+    /// let mut q_low_first = PriorityQueue::<_, _, Min>::new();
+    /// q_low_first.push(2,2);
+    /// ```
+    ///
+    pub fn new() -> Self {
+        Self {
+            heap: BinaryHeap::new(),
+            seq: 0,
+        }
+    }
+
+    fn pop_inner(&mut self) -> Option<(T, P)>
+    where
+        O: QueueOrder,
+    {
+        self.heap
+            .pop()
+            .map(|RankedItem { item, priority, .. }| (item, priority))
+    }
+
+    fn push_inner(&mut self, item: T, priority: P)
+    where
+        O: QueueOrder,
+    {
+        self.seq += 1;
+        self.heap.push(RankedItem {
+            item,
+            priority,
+            seq: self.seq,
+            _order: PhantomData,
+        });
+    }
+}
+
+impl<P: Ord, T> PriorityQueue<P, T, Max> {
+    /// Take the highest ranked item (and assigned priority value) from the queue.
+    pub fn pop(&mut self) -> Option<(T, P)> {
+        self.pop_inner()
+    }
+
+    /// Add an item to the queue with the given priority.
+    pub fn push(&mut self, item: T, priority: P) {
+        self.push_inner(item, priority);
+    }
+}
+
+impl<P: Ord, T> PriorityQueue<P, T, Min> {
+    /// Take the lowest ranked item (and assigned priority value) from the queue.
+    pub fn pop(&mut self) -> Option<(T, P)> {
+        self.pop_inner()
+    }
+
+    /// Add an item to the queue with the given priority.
+    pub fn push(&mut self, item: T, priority: P) {
+        self.push_inner(item, priority);
+    }
+}
+
+/// Trait used to define ordering for `RankedItem<P, T, O: QueueOrder>` and enable alternative
+/// min-heap behavior from `std::collections::BinaryHeap`.
+trait QueueOrder {
+    /// Determine ordering between two items based on priority and sequence (insertion) order.
+    fn cmp<P: Ord>(lhs_priority: &P, lhs_seq: u64, rhs_priority: &P, rhs_seq: u64) -> Ordering;
+}
+
+impl QueueOrder for Max {
+    fn cmp<P: Ord>(lhs_priority: &P, lhs_seq: u64, rhs_priority: &P, rhs_seq: u64) -> Ordering {
+        lhs_priority.cmp(rhs_priority).then(rhs_seq.cmp(&lhs_seq))
+    }
+}
+
+impl QueueOrder for Min {
+    fn cmp<P: Ord>(lhs_priority: &P, lhs_seq: u64, rhs_priority: &P, rhs_seq: u64) -> Ordering {
+        lhs_priority
+            .cmp(rhs_priority)
+            .reverse()
+            .then(rhs_seq.cmp(&lhs_seq))
+    }
+}
+
+/// An item on the `PriorityQueue` with a defined `priority` and sequence number.
+#[derive(Debug)]
+struct RankedItem<P, T, O>
+where
+    P: Ord,
+{
+    item: T,
+    priority: P,
+    seq: u64,
+    _order: PhantomData<O>,
+}
+
+impl<P, T, O> Ord for RankedItem<P, T, O>
+where
+    P: Ord,
+    O: QueueOrder,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        O::cmp(&self.priority, self.seq, &other.priority, other.seq)
+    }
+}
+
+impl<P, T, O> PartialOrd for RankedItem<P, T, O>
+where
+    P: Ord,
+    O: QueueOrder,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<P, T, O> Eq for RankedItem<P, T, O>
+where
+    P: Ord,
+    O: QueueOrder,
+{
+}
+
+impl<P, T, O> PartialEq for RankedItem<P, T, O>
+where
+    P: Ord,
+    O: QueueOrder,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.priority == other.priority && self.seq == other.seq
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_push_pop_max() {
+        let mut q = MaxPriorityQ::new();
+        q.push('c', 3);
+        q.push('a', 1);
+        q.push('b', 2);
+        assert_eq!(q.pop(), Some(('c', 3)));
+        assert_eq!(q.pop(), Some(('b', 2)));
+        assert_eq!(q.pop(), Some(('a', 1)));
+        assert_eq!(q.pop(), None);
+    }
+
+    #[test]
+    fn test_push_pop_min() {
+        let mut q = MinPriorityQ::new();
+        q.push('c', 3);
+        q.push('a', 1);
+        q.push('b', 2);
+        assert_eq!(q.pop(), Some(('a', 1)));
+        assert_eq!(q.pop(), Some(('b', 2)));
+        assert_eq!(q.pop(), Some(('c', 3)));
+        assert_eq!(q.pop(), None);
+    }
+
+    #[test]
+    fn ties_returned_in_insertion_order() {
+        let mut q = MaxPriorityQ::new();
+        q.push('a', 3);
+        q.push('b', 3);
+        q.push('c', 3);
+        assert_eq!(q.pop(), Some(('a', 3)));
+        assert_eq!(q.pop(), Some(('b', 3)));
+        assert_eq!(q.pop(), Some(('c', 3)));
+        assert_eq!(q.pop(), None);
+
+        let mut q = MinPriorityQ::new();
+        q.push('a', 3);
+        q.push('b', 3);
+        q.push('c', 3);
+        assert_eq!(q.pop(), Some(('a', 3)));
+        assert_eq!(q.pop(), Some(('b', 3)));
+        assert_eq!(q.pop(), Some(('c', 3)));
+        assert_eq!(q.pop(), None);
+    }
+}

--- a/src/ordering/priority_queue.rs
+++ b/src/ordering/priority_queue.rs
@@ -1,49 +1,68 @@
-//! `PriorityQueue` - a collection of items that can be handled in a prioritized order.
+//! Priority queue utilities for retrieving only the next highest- or lowest-priority item.
+//!
+//! `PriorityQueue` is backed by a `BinaryHeap`, so it is the better fit when you
+//! care about fast insertion and removal of the next item rather than inspecting
+//! the full ordering of the collection.
+//!
+//! # Examples
+//!
+//! ```
+//! use gametools::ordering::{MaxPriorityQ, MinPriorityQ};
+//!
+//! let mut max_q = MaxPriorityQ::new();
+//! max_q.push("low", 1);
+//! max_q.push("high", 3);
+//!
+//! assert_eq!(max_q.pop(), Some(("high", 3)));
+//!
+//! let mut min_q = MinPriorityQ::new();
+//! min_q.push("late", 10);
+//! min_q.push("soon", 5);
+//!
+//! assert_eq!(min_q.pop(), Some(("soon", 5)));
+//! ```
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::marker::PhantomData;
 
+/// A [`PriorityQueue`] that yields the highest-priority items first.
 pub type MaxPriorityQ<P, T> = PriorityQueue<P, T, Max>;
+/// A [`PriorityQueue`] that yields the lowest-priority items first.
 pub type MinPriorityQ<P, T> = PriorityQueue<P, T, Min>;
 
-/// Type used to indicate that the `PriorityQueue` should yield the highest priority items first.
+/// Marker type for [`PriorityQueue`] values that yield the highest-priority items first.
 pub struct Max;
-/// Type used to indicate that the `PriorityQueue` should yield the lowest priority items first.
+/// Marker type for [`PriorityQueue`] values that yield the lowest-priority items first.
 pub struct Min;
 
-/// # `PriorityQueue<P, T, O = Max>`
+/// A priority queue with stable tie-breaking by insertion order.
 ///
-/// A collection that yields its items in a ranked order. If two or more items tie on
-/// priority, they are returned in the order they were inserted.
+/// This queue returns only the next item in priority order. When two items share
+/// the same priority, the item that was inserted first is returned first.
 ///
 /// # Type Parameters
-/// - `P: Ord` - the type (typically numeric) of the priority values
-/// - `T` - the type of the items in the queue
-/// - `O = Max` - determines whether the `Max` (default) or `Min` items are yielded first.
+/// - `P: Ord` - the priority value type.
+/// - `T` - the stored item type.
+/// - `O = Max` - the ordering marker, typically [`Max`] or [`Min`].
 ///
 /// # Aliases
-/// - `MaxPriorityQ<P, T>`: A priority queue that yields the highest priority items first.
-/// - `MinPriorityQ<P, T>`: A priority queue that yields the lowest priority items first.
+/// - [`MaxPriorityQ<P, T>`]: highest priorities first.
+/// - [`MinPriorityQ<P, T>`]: lowest priorities first.
 ///
 /// # Examples
 ///
 /// ```
-/// use gametools::ordering::priority_queue::{MaxPriorityQ, MinPriorityQ};
+/// use gametools::ordering::{PriorityQueue, Min};
 ///
-/// let mut max_q = MaxPriorityQ::new();
-/// let mut min_q = MinPriorityQ::new();
+/// let mut queue = PriorityQueue::<_, _, Min>::new();
+/// queue.push("boss", 10);
+/// queue.push("minion", 1);
 ///
-/// max_q.push("high", 10);
-/// max_q.push("low", 5);
-///
-/// min_q.push("high", 10);
-/// min_q.push("low", 5);
-///
-/// assert_eq!(max_q.pop(), Some(("high", 10)));
-/// assert_eq!(min_q.pop(), Some(("low", 5)));
+/// assert_eq!(queue.pop(), Some(("minion", 1)));
+/// assert_eq!(queue.pop(), Some(("boss", 10)));
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PriorityQueue<P, T, O = Max>
 where
     P: Ord,
@@ -52,21 +71,23 @@ where
     seq: u64,
 }
 impl<P: Ord, T, O> PriorityQueue<P, T, O> {
-    /// Create a new, empty `PriorityQueue`.
+    /// Creates an empty `PriorityQueue`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use gametools::ordering::priority_queue::{MaxPriorityQ, PriorityQueue, Min};
+    /// use gametools::ordering::{MaxPriorityQ, PriorityQueue, Min};
     ///
-    /// let mut q_high_first = MaxPriorityQ::new();
-    /// q_high_first.push("foo", 1);
+    /// let mut max_q = MaxPriorityQ::new();
+    /// max_q.push("token", 1);
     ///
-    /// // or more verbose / explicit
-    /// let mut q_low_first = PriorityQueue::<_, _, Min>::new();
-    /// q_low_first.push(2,2);
+    /// let mut min_q = PriorityQueue::<_, _, Min>::new();
+    /// min_q.push("token", 1);
+    ///
+    /// assert_eq!(max_q.pop(), Some(("token", 1)));
+    /// assert_eq!(min_q.pop(), Some(("token", 1)));
     /// ```
-    ///
+    #[must_use]
     pub fn new() -> Self {
         Self {
             heap: BinaryHeap::new(),
@@ -98,33 +119,89 @@ impl<P: Ord, T, O> PriorityQueue<P, T, O> {
 }
 
 impl<P: Ord, T> PriorityQueue<P, T, Max> {
-    /// Take the highest ranked item (and assigned priority value) from the queue.
+    /// Removes and returns the highest-priority item.
+    ///
+    /// Returns `None` if the queue is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::MaxPriorityQ;
+    ///
+    /// let mut queue = MaxPriorityQ::new();
+    /// queue.push("low", 1);
+    /// queue.push("high", 2);
+    ///
+    /// assert_eq!(queue.pop(), Some(("high", 2)));
+    /// assert_eq!(queue.pop(), Some(("low", 1)));
+    /// assert_eq!(queue.pop(), None);
+    /// ```
     pub fn pop(&mut self) -> Option<(T, P)> {
         self.pop_inner()
     }
 
-    /// Add an item to the queue with the given priority.
+    /// Inserts an item with the given priority.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::MaxPriorityQ;
+    ///
+    /// let mut queue = MaxPriorityQ::new();
+    /// queue.push("alpha", 1);
+    /// queue.push("beta", 2);
+    ///
+    /// assert_eq!(queue.pop(), Some(("beta", 2)));
+    /// ```
     pub fn push(&mut self, item: T, priority: P) {
         self.push_inner(item, priority);
     }
 }
 
 impl<P: Ord, T> PriorityQueue<P, T, Min> {
-    /// Take the lowest ranked item (and assigned priority value) from the queue.
+    /// Removes and returns the lowest-priority item.
+    ///
+    /// Returns `None` if the queue is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::MinPriorityQ;
+    ///
+    /// let mut queue = MinPriorityQ::new();
+    /// queue.push("late", 3);
+    /// queue.push("soon", 1);
+    ///
+    /// assert_eq!(queue.pop(), Some(("soon", 1)));
+    /// assert_eq!(queue.pop(), Some(("late", 3)));
+    /// assert_eq!(queue.pop(), None);
+    /// ```
     pub fn pop(&mut self) -> Option<(T, P)> {
         self.pop_inner()
     }
 
-    /// Add an item to the queue with the given priority.
+    /// Inserts an item with the given priority.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::MinPriorityQ;
+    ///
+    /// let mut queue = MinPriorityQ::new();
+    /// queue.push("late", 3);
+    /// queue.push("soon", 1);
+    ///
+    /// assert_eq!(queue.pop(), Some(("soon", 1)));
+    /// ```
     pub fn push(&mut self, item: T, priority: P) {
         self.push_inner(item, priority);
     }
 }
 
-/// Trait used to define ordering for `RankedItem<P, T, O: QueueOrder>` and enable alternative
-/// min-heap behavior from `std::collections::BinaryHeap`.
+/// Ordering strategy used internally by [`PriorityQueue`] to support max-heap
+/// and min-heap behavior with the same underlying `BinaryHeap`.
 trait QueueOrder {
-    /// Determine ordering between two items based on priority and sequence (insertion) order.
+    /// Compares two `(priority, insertion-sequence)` pairs.
     fn cmp<P: Ord>(lhs_priority: &P, lhs_seq: u64, rhs_priority: &P, rhs_seq: u64) -> Ordering;
 }
 
@@ -143,7 +220,7 @@ impl QueueOrder for Min {
     }
 }
 
-/// An item on the `PriorityQueue` with a defined `priority` and sequence number.
+/// An item stored in the heap with its priority and insertion sequence number.
 #[derive(Debug)]
 struct RankedItem<P, T, O>
 where
@@ -239,5 +316,35 @@ mod test {
         assert_eq!(q.pop(), Some(('b', 3)));
         assert_eq!(q.pop(), Some(('c', 3)));
         assert_eq!(q.pop(), None);
+    }
+
+    #[test]
+    fn empty_queues_pop_none() {
+        let mut max_q: MaxPriorityQ<i32, char> = MaxPriorityQ::new();
+        let mut min_q: MinPriorityQ<i32, char> = MinPriorityQ::new();
+
+        assert_eq!(max_q.pop(), None);
+        assert_eq!(min_q.pop(), None);
+    }
+
+    #[test]
+    fn explicit_generic_construction_respects_order_marker() {
+        let mut max_q = PriorityQueue::<_, _, Max>::new();
+        max_q.push("mid", 2);
+        max_q.push("high", 3);
+        max_q.push("low", 1);
+
+        assert_eq!(max_q.pop(), Some(("high", 3)));
+        assert_eq!(max_q.pop(), Some(("mid", 2)));
+        assert_eq!(max_q.pop(), Some(("low", 1)));
+
+        let mut min_q = PriorityQueue::<_, _, Min>::new();
+        min_q.push("mid", 2);
+        min_q.push("high", 3);
+        min_q.push("low", 1);
+
+        assert_eq!(min_q.pop(), Some(("low", 1)));
+        assert_eq!(min_q.pop(), Some(("mid", 2)));
+        assert_eq!(min_q.pop(), Some(("high", 3)));
     }
 }

--- a/src/ordering/ranked_order.rs
+++ b/src/ordering/ranked_order.rs
@@ -1,0 +1,129 @@
+use std::marker::PhantomData;
+
+pub type DescendingOrder<R, T> = RankedOrder<R, T, Descending>;
+pub type AscendingOrder<R, T> = RankedOrder<R, T, Ascending>;
+
+pub struct RankedOrder<R: Ord, T, D>
+where
+    D: Direction,
+{
+    items: Vec<RankedItem<R, T, D>>,
+    seq: u64,
+    is_dirty: bool,
+}
+
+impl<R: Ord, T, D> RankedOrder<R, T, D>
+where
+    D: Direction,
+{
+    pub fn new() -> Self {
+        Self {
+            items: Vec::new(),
+            seq: 0,
+            is_dirty: false,
+        }
+    }
+
+    fn push_inner(&mut self, item: T, rank: R)
+    where
+        D: Direction,
+    {
+        self.seq = self.seq.wrapping_add(1);
+        self.items
+            .push(RankedItem::new(item, rank, self.seq, PhantomData));
+        self.is_dirty = true;
+    }
+
+    fn pop_inner(&mut self) -> Option<(T, R)> {
+        if self.is_dirty {
+            self.items.sort()
+        }
+        self.items.pop().map(|ri| (ri.item, ri.rank))
+    }
+}
+
+impl<R: Ord, T> RankedOrder<R, T, Descending> {
+    pub fn push(&mut self, item: T, rank: R) {
+        self.push_inner(item, rank);
+    }
+
+    pub fn pop(&mut self) -> Option<(T, R)> {
+        self.pop_inner()
+    }
+}
+
+impl<R: Ord, T> RankedOrder<R, T, Ascending> {
+    pub fn push(&mut self, item: T, rank: R) {
+        self.push_inner(item, rank);
+    }
+
+    pub fn pop(&mut self) -> Option<(T, R)> {
+        self.pop_inner()
+    }
+}
+
+struct RankedItem<R: Ord, T, D>
+where
+    D: Direction,
+{
+    item: T,
+    rank: R,
+    seq: u64,
+    _direction: std::marker::PhantomData<D>,
+}
+
+impl<R: Ord, T, D> RankedItem<R, T, D>
+where
+    D: Direction,
+{
+    fn new(item: T, rank: R, seq: u64, _direction: std::marker::PhantomData<D>) -> Self {
+        Self {
+            item,
+            rank,
+            seq,
+            _direction: std::marker::PhantomData,
+        }
+    }
+}
+impl<R: Ord, T, D> Ord for RankedItem<R, T, D>
+where
+    D: Direction,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        D::cmp(&self.rank, self.seq, &other.rank, other.seq)
+    }
+}
+impl<R: Ord, T, D> PartialOrd for RankedItem<R, T, D>
+where
+    D: Direction,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<R: Ord, T, D> Eq for RankedItem<R, T, D> where D: Direction {}
+impl<R: Ord, T, D> PartialEq for RankedItem<R, T, D>
+where
+    D: Direction,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+pub struct Ascending;
+pub struct Descending;
+
+pub trait Direction {
+    fn cmp<R: Ord>(lhs_rank: &R, lhs_seq: u64, rhs_rank: &R, rhs_seq: u64) -> std::cmp::Ordering;
+}
+impl Direction for Ascending {
+    fn cmp<R: Ord>(lhs_rank: &R, lhs_seq: u64, rhs_rank: &R, rhs_seq: u64) -> std::cmp::Ordering {
+        rhs_rank.cmp(lhs_rank).then(rhs_seq.cmp(&lhs_seq))
+    }
+}
+impl Direction for Descending {
+    fn cmp<R: Ord>(lhs_rank: &R, lhs_seq: u64, rhs_rank: &R, rhs_seq: u64) -> std::cmp::Ordering {
+        lhs_rank.cmp(rhs_rank).then(lhs_seq.cmp(&rhs_seq))
+    }
+}

--- a/src/ordering/ranked_order.rs
+++ b/src/ordering/ranked_order.rs
@@ -1,6 +1,63 @@
+//! Stable ranked ordering utilities.
+//!
+//! `RankedOrder` stores the full ordered list of items instead of optimizing only
+//! for the next item to be removed. That makes it useful when you need to inspect
+//! or materialize the whole ordering while still preserving insertion order for
+//! ties.
+//!
+//! # Examples
+//!
+//! ```
+//! use gametools::ordering::{AscendingOrder, DescendingOrder};
+//!
+//! let mut descending = DescendingOrder::new();
+//! descending.push("low", 1);
+//! descending.push("high", 3);
+//! descending.push("also high", 3);
+//!
+//! assert_eq!(descending.pop(), Some(("high", 3)));
+//! assert_eq!(descending.pop(), Some(("also high", 3)));
+//!
+//! let mut ascending = AscendingOrder::new();
+//! ascending.push("medium", 2);
+//! ascending.push("low", 1);
+//! ascending.push("high", 3);
+//!
+//! assert_eq!(ascending.into_sorted_vec(), vec![("low", 1), ("medium", 2), ("high", 3)]);
+//! ```
+/// A [`RankedOrder`] that yields the lowest-ranked items first.
 pub type AscendingOrder<R, T> = RankedOrder<R, T, Ascending>;
+/// A [`RankedOrder`] that yields the highest-ranked items first.
 pub type DescendingOrder<R, T> = RankedOrder<R, T, Descending>;
 
+/// A stable ranked collection that can be viewed or consumed in sorted order.
+///
+/// The `D` type parameter controls whether lower ranks are yielded first
+/// ([`Ascending`]) or higher ranks are yielded first ([`Descending`]).
+/// When two items have the same rank, they are yielded in insertion order.
+///
+/// # Type Parameters
+/// - `R: Ord` - the rank value used to sort items.
+/// - `T` - the stored item type.
+/// - `D: Direction` - the ordering direction used for ranked comparisons.
+///
+/// # Aliases
+/// - [`AscendingOrder<R, T>`]: lower ranks first.
+/// - [`DescendingOrder<R, T>`]: higher ranks first.
+///
+/// # Examples
+///
+/// ```
+/// use gametools::ordering::{Descending, RankedOrder};
+///
+/// let mut order = RankedOrder::<_, _, Descending>::new();
+/// order.push("silver", 2);
+/// order.push("gold", 3);
+///
+/// assert_eq!(order.pop(), Some(("gold", 3)));
+/// assert_eq!(order.pop(), Some(("silver", 2)));
+/// ```
+#[derive(Debug, Default)]
 pub struct RankedOrder<R, T, D>
 where
     D: Direction,
@@ -16,6 +73,19 @@ where
     D: Direction,
     R: Ord,
 {
+    /// Creates an empty `RankedOrder`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::AscendingOrder;
+    ///
+    /// let mut order = AscendingOrder::new();
+    /// order.push("first", 1);
+    ///
+    /// assert_eq!(order.pop(), Some(("first", 1)));
+    /// ```
+    #[must_use]
     pub fn new() -> Self {
         Self {
             items: Vec::new(),
@@ -24,19 +94,188 @@ where
         }
     }
 
+    /// Inserts an item with an explicit rank value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::DescendingOrder;
+    ///
+    /// let mut order = DescendingOrder::new();
+    /// order.push("bronze", 1);
+    /// order.push("gold", 3);
+    ///
+    /// assert_eq!(order.pop(), Some(("gold", 3)));
+    /// ```
     pub fn push(&mut self, item: T, rank: R) {
         self.push_inner(item, rank);
     }
 
+    /// Inserts an item after computing its rank from the item itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::DescendingOrder;
+    ///
+    /// let mut order = DescendingOrder::new();
+    /// order.push_with_ranker("wizard", |name| name.len());
+    /// order.push_with_ranker("rogue", |name| name.len());
+    ///
+    /// assert_eq!(order.pop(), Some(("wizard", 6)));
+    /// assert_eq!(order.pop(), Some(("rogue", 5)));
+    /// ```
     pub fn push_with_ranker<F: FnOnce(&T) -> R>(&mut self, item: T, ranker: F) {
         let rank = ranker(&item);
         self.push_inner(item, rank);
     }
 
+    /// Removes and returns the next item in ranked order.
+    ///
+    /// Returns `None` if the collection is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::AscendingOrder;
+    ///
+    /// let mut order = AscendingOrder::new();
+    /// order.push("later", 2);
+    /// order.push("sooner", 1);
+    ///
+    /// assert_eq!(order.pop(), Some(("sooner", 1)));
+    /// assert_eq!(order.pop(), Some(("later", 2)));
+    /// assert_eq!(order.pop(), None);
+    /// ```
     pub fn pop(&mut self) -> Option<(T, R)> {
         self.pop_inner()
     }
 
+    /// Peek at the next item in ranked order without consuming it.
+    ///
+    /// Returns `None` if the collection is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::AscendingOrder;
+    ///
+    /// let mut order = AscendingOrder::new();
+    /// order.push("later", 2);
+    /// order.push("sooner", 1);
+    ///
+    /// assert_eq!(order.peek(), Some((&"sooner", &1)));
+    /// assert_eq!(order.peek(), Some((&"sooner", &1)));
+    /// ```
+    #[must_use]
+    pub fn peek(&mut self) -> Option<(&T, &R)> {
+        self.lazy_sort();
+        self.items.last().map(|ri| (&ri.item, &ri.rank))
+    }
+
+    /// Returns the number of items in the collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::AscendingOrder;
+    ///
+    /// let mut order = AscendingOrder::new();
+    /// order.push("later", 2);
+    /// order.push("sooner", 1);
+    ///
+    /// assert_eq!(order.len(), 2);
+    /// ```
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns `true` if the collection is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::AscendingOrder;
+    ///
+    /// let mut order = AscendingOrder::new();
+    /// order.push("later", 2);
+    /// order.push("sooner", 1);
+    ///
+    /// assert!(!order.is_empty());
+    /// ```
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Returns the minimum and maximum rank in the collection, if any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::AscendingOrder;
+    ///
+    /// let mut order = AscendingOrder::new();
+    /// order.push('c', 3);
+    /// order.push('a', 1);
+    /// order.push('b', 2);
+    ///
+    /// assert_eq!(order.rank_range(), Some((1, 3)));
+    /// ```
+    #[must_use]
+    pub fn rank_range(&self) -> Option<(R, R)>
+    where
+        R: Copy,
+    {
+        let init = self.items.first().map(|ri| ri.rank)?;
+        let range = self
+            .items
+            .iter()
+            .skip(1)
+            .map(|ri| ri.rank)
+            .fold((init, init), |acc, rank| (acc.0.min(rank), acc.1.max(rank)));
+        Some(range)
+    }
+
+    /// Re-ranks all items using the given ranker function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::AscendingOrder;
+    ///
+    /// let mut order = AscendingOrder::new();
+    /// order.push('c', 3);
+    /// order.push('a', 1);
+    /// order.push('b', 2);
+    ///
+    /// order.rerank_all_by(|c| *c as u8);
+    ///
+    /// assert_eq!(order.into_sorted_vec(), vec![('a', 97), ('b', 98), ('c', 99)]);
+    /// ```
+    pub fn rerank_all_by<F: Fn(&T) -> R>(&mut self, ranker: F) {
+        for item in self.items.iter_mut() {
+            item.rank = ranker(&item.item);
+        }
+        self.is_dirty = true;
+    }
+
+    /// Consumes the collection and returns all items as a sorted vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::AscendingOrder;
+    ///
+    /// let mut order = AscendingOrder::new();
+    /// order.push('c', 3);
+    /// order.push('a', 1);
+    /// order.push('b', 2);
+    ///
+    /// assert_eq!(order.into_sorted_vec(), vec![('a', 1), ('b', 2), ('c', 3)]);
+    /// ```
+    #[must_use]
     pub fn into_sorted_vec(mut self) -> Vec<(T, R)> {
         self.lazy_sort();
         self.items
@@ -46,6 +285,26 @@ where
             .collect()
     }
 
+    /// Returns an iterator over the items in ranked order without consuming them.
+    ///
+    /// The iterator yields references to `(item, rank)` pairs. This method takes
+    /// `&mut self` because sorting is deferred until the ordered view is needed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gametools::ordering::DescendingOrder;
+    ///
+    /// let mut order = DescendingOrder::new();
+    /// order.push("bronze", 1);
+    /// order.push("silver", 2);
+    /// order.push("gold", 3);
+    ///
+    /// assert_eq!(
+    ///     order.iter_sorted().collect::<Vec<_>>(),
+    ///     vec![(&"gold", &3), (&"silver", &2), (&"bronze", &1)]
+    /// );
+    /// ```
     pub fn iter_sorted(&mut self) -> impl Iterator<Item = (&T, &R)> {
         self.lazy_sort();
         self.items.iter().rev().map(|ri| (&ri.item, &ri.rank))
@@ -70,6 +329,7 @@ where
     }
 }
 
+#[derive(Debug)]
 struct RankedItem<R, T, D>
 where
     D: Direction,
@@ -128,10 +388,17 @@ where
     }
 }
 
+/// Marker type for [`RankedOrder`] values that yield the lowest-ranked items first.
 pub struct Ascending;
+/// Marker type for [`RankedOrder`] values that yield the highest-ranked items first.
 pub struct Descending;
 
+/// Strategy trait that defines how two ranked items are compared.
+///
+/// This is primarily intended for the built-in [`Ascending`] and [`Descending`]
+/// marker types.
 pub trait Direction {
+    /// Compares two `(rank, insertion-sequence)` pairs using a concrete direction.
     fn cmp<R: Ord>(lhs_rank: &R, lhs_seq: u64, rhs_rank: &R, rhs_seq: u64) -> std::cmp::Ordering;
 }
 impl Direction for Ascending {
@@ -214,5 +481,45 @@ mod tests {
             ascender.into_sorted_vec(),
             vec![('a', 1), ('b', 2), ('c', 3)]
         );
+    }
+
+    #[test]
+    fn push_with_ranker_uses_computed_rank() {
+        let mut descender = DescendingOrder::new();
+        descender.push_with_ranker("aaa", |item| item.len());
+        descender.push_with_ranker("b", |item| item.len());
+        descender.push_with_ranker("cc", |item| item.len());
+
+        assert_eq!(
+            descender.into_sorted_vec(),
+            vec![("aaa", 3), ("cc", 2), ("b", 1)]
+        );
+    }
+
+    #[test]
+    fn pop_returns_none_when_empty() {
+        let mut descender: DescendingOrder<i32, char> = DescendingOrder::new();
+        let mut ascender: AscendingOrder<i32, char> = AscendingOrder::new();
+
+        assert_eq!(descender.pop(), None);
+        assert_eq!(ascender.pop(), None);
+    }
+
+    #[test]
+    fn pushing_after_sorted_access_restores_ordering() {
+        let mut descender = DescendingOrder::new();
+        descender.push('a', 1);
+        descender.push('b', 3);
+
+        assert_eq!(
+            descender.iter_sorted().collect::<Vec<_>>(),
+            vec![(&'b', &3), (&'a', &1)]
+        );
+
+        descender.push('c', 2);
+
+        assert_eq!(descender.pop(), Some(('b', 3)));
+        assert_eq!(descender.pop(), Some(('c', 2)));
+        assert_eq!(descender.pop(), Some(('a', 1)));
     }
 }

--- a/src/ordering/ranked_order.rs
+++ b/src/ordering/ranked_order.rs
@@ -1,20 +1,20 @@
-use std::marker::PhantomData;
-
-pub type DescendingOrder<R, T> = RankedOrder<R, T, Descending>;
 pub type AscendingOrder<R, T> = RankedOrder<R, T, Ascending>;
+pub type DescendingOrder<R, T> = RankedOrder<R, T, Descending>;
 
-pub struct RankedOrder<R: Ord, T, D>
+pub struct RankedOrder<R, T, D>
 where
     D: Direction,
+    R: Ord,
 {
     items: Vec<RankedItem<R, T, D>>,
     seq: u64,
     is_dirty: bool,
 }
 
-impl<R: Ord, T, D> RankedOrder<R, T, D>
+impl<R, T, D> RankedOrder<R, T, D>
 where
     D: Direction,
+    R: Ord,
 {
     pub fn new() -> Self {
         Self {
@@ -24,47 +24,56 @@ where
         }
     }
 
-    fn push_inner(&mut self, item: T, rank: R)
-    where
-        D: Direction,
-    {
-        self.seq = self.seq.wrapping_add(1);
+    pub fn push(&mut self, item: T, rank: R) {
+        self.push_inner(item, rank);
+    }
+
+    pub fn push_with_ranker<F: FnOnce(&T) -> R>(&mut self, item: T, ranker: F) {
+        let rank = ranker(&item);
+        self.push_inner(item, rank);
+    }
+
+    pub fn pop(&mut self) -> Option<(T, R)> {
+        self.pop_inner()
+    }
+
+    pub fn into_sorted_vec(mut self) -> Vec<(T, R)> {
+        self.lazy_sort();
         self.items
-            .push(RankedItem::new(item, rank, self.seq, PhantomData));
+            .into_iter()
+            .rev()
+            .map(|ri| (ri.item, ri.rank))
+            .collect()
+    }
+
+    pub fn iter_sorted(&mut self) -> impl Iterator<Item = (&T, &R)> {
+        self.lazy_sort();
+        self.items.iter().rev().map(|ri| (&ri.item, &ri.rank))
+    }
+
+    fn push_inner(&mut self, item: T, rank: R) {
+        self.seq = self.seq.wrapping_add(1);
+        self.items.push(RankedItem::new(item, rank, self.seq));
         self.is_dirty = true;
     }
 
     fn pop_inner(&mut self) -> Option<(T, R)> {
-        if self.is_dirty {
-            self.items.sort()
-        }
+        self.lazy_sort();
         self.items.pop().map(|ri| (ri.item, ri.rank))
     }
-}
 
-impl<R: Ord, T> RankedOrder<R, T, Descending> {
-    pub fn push(&mut self, item: T, rank: R) {
-        self.push_inner(item, rank);
-    }
-
-    pub fn pop(&mut self) -> Option<(T, R)> {
-        self.pop_inner()
+    fn lazy_sort(&mut self) {
+        if self.is_dirty {
+            self.items.sort();
+            self.is_dirty = false;
+        }
     }
 }
 
-impl<R: Ord, T> RankedOrder<R, T, Ascending> {
-    pub fn push(&mut self, item: T, rank: R) {
-        self.push_inner(item, rank);
-    }
-
-    pub fn pop(&mut self) -> Option<(T, R)> {
-        self.pop_inner()
-    }
-}
-
-struct RankedItem<R: Ord, T, D>
+struct RankedItem<R, T, D>
 where
     D: Direction,
+    R: Ord,
 {
     item: T,
     rank: R,
@@ -72,11 +81,12 @@ where
     _direction: std::marker::PhantomData<D>,
 }
 
-impl<R: Ord, T, D> RankedItem<R, T, D>
+impl<R, T, D> RankedItem<R, T, D>
 where
     D: Direction,
+    R: Ord,
 {
-    fn new(item: T, rank: R, seq: u64, _direction: std::marker::PhantomData<D>) -> Self {
+    fn new(item: T, rank: R, seq: u64) -> Self {
         Self {
             item,
             rank,
@@ -85,26 +95,33 @@ where
         }
     }
 }
-impl<R: Ord, T, D> Ord for RankedItem<R, T, D>
+
+impl<R, T, D> Ord for RankedItem<R, T, D>
 where
     D: Direction,
+    R: Ord,
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         D::cmp(&self.rank, self.seq, &other.rank, other.seq)
     }
 }
-impl<R: Ord, T, D> PartialOrd for RankedItem<R, T, D>
+
+impl<R, T, D> PartialOrd for RankedItem<R, T, D>
 where
     D: Direction,
+    R: Ord,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
+
 impl<R: Ord, T, D> Eq for RankedItem<R, T, D> where D: Direction {}
-impl<R: Ord, T, D> PartialEq for RankedItem<R, T, D>
+
+impl<R, T, D> PartialEq for RankedItem<R, T, D>
 where
     D: Direction,
+    R: Ord,
 {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == std::cmp::Ordering::Equal
@@ -124,6 +141,78 @@ impl Direction for Ascending {
 }
 impl Direction for Descending {
     fn cmp<R: Ord>(lhs_rank: &R, lhs_seq: u64, rhs_rank: &R, rhs_seq: u64) -> std::cmp::Ordering {
-        lhs_rank.cmp(rhs_rank).then(lhs_seq.cmp(&rhs_seq))
+        lhs_rank.cmp(rhs_rank).then(rhs_seq.cmp(&lhs_seq))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rank_ties_maintain_original_insertion_order() {
+        let mut descender = DescendingOrder::new();
+        descender.push('a', 1);
+        descender.push('b', 1);
+        descender.push('c', 1);
+
+        assert_eq!(descender.pop(), Some(('a', 1)));
+        assert_eq!(descender.pop(), Some(('b', 1)));
+        assert_eq!(descender.pop(), Some(('c', 1)));
+
+        let mut ascender = AscendingOrder::new();
+        ascender.push('a', 1);
+        ascender.push('b', 1);
+        ascender.push('c', 1);
+
+        assert_eq!(ascender.pop(), Some(('a', 1)));
+        assert_eq!(ascender.pop(), Some(('b', 1)));
+        assert_eq!(ascender.pop(), Some(('c', 1)));
+    }
+
+    #[test]
+    fn iter_sorted_respects_direction() {
+        let mut descender = DescendingOrder::new();
+        descender.push('a', 1);
+        descender.push('b', 2);
+        descender.push('c', 3);
+
+        assert_eq!(
+            descender.iter_sorted().collect::<Vec<_>>(),
+            vec![(&'c', &3), (&'b', &2), (&'a', &1)]
+        );
+
+        let mut ascender = AscendingOrder::new();
+        ascender.push('a', 1);
+        ascender.push('b', 2);
+        ascender.push('c', 3);
+
+        assert_eq!(
+            ascender.iter_sorted().collect::<Vec<_>>(),
+            vec![(&'a', &1), (&'b', &2), (&'c', &3)]
+        );
+    }
+
+    #[test]
+    fn into_sorted_vec_respects_direction() {
+        let mut descender = DescendingOrder::new();
+        descender.push('a', 1);
+        descender.push('b', 2);
+        descender.push('c', 3);
+
+        assert_eq!(
+            descender.into_sorted_vec(),
+            vec![('c', 3), ('b', 2), ('a', 1)]
+        );
+
+        let mut ascender = AscendingOrder::new();
+        ascender.push('a', 1);
+        ascender.push('b', 2);
+        ascender.push('c', 3);
+
+        assert_eq!(
+            ascender.into_sorted_vec(),
+            vec![('a', 1), ('b', 2), ('c', 3)]
+        );
     }
 }


### PR DESCRIPTION
# Ordering

- `ordering` module added, includes `RankedOrder<R, T, D>` and `PriorityQueue<P, T, O>`
- `RankedOrder` is Vec-backed and optimized for use in batches and inspection of the total order
- `PriorityQueue` is BinaryHeap-backed and optimized for rapid push/pop throughput and access to the top item only
- in all of the above cases, min vs max function is achieved cost-free via the type system and without the need for wrapping types in a Reverse<T>. 
- examples were added for these in the examples folder
- other small adjustments to GameError, re-exports, docs and docstrings