### PR TITLE
Prepare 0.9.0

### DIFF
--- a/src/cards.rs
+++ b/src/cards.rs
@@ -89,7 +89,7 @@ pub use hand::{Hand, Hand as CardHand};
 pub use pile::Pile;
 pub use std_playing_cards::{Rank, StandardCard, Suit};
 
-use crate::GameError;
+use crate::{CardError, GameResult};
 
 /// Shared behaviors for card containers such as [`Deck`], [`Hand`], and [`Pile`].
 pub trait CardCollection {
@@ -183,8 +183,8 @@ pub trait TakeCard<T: CardFaces> {
 /// The sender must implement `TakeCard` and the receiver, `AddCard`.
 ///
 /// # Errors
-/// - `GameError::CardNotFound` if the specified `Card` does not belong to the `sender`.
-pub fn transfer_card<C, S, R>(card: &Card<C>, sender: &mut S, recv: &mut R) -> Result<(), GameError>
+/// - [`CardError::CardNotFound`] if the specified `Card` does not belong to the `sender`.
+pub fn transfer_card<C, S, R>(card: &Card<C>, sender: &mut S, recv: &mut R) -> GameResult<()>
 where
     C: CardFaces,
     S: TakeCard<C>,
@@ -194,7 +194,7 @@ where
         recv.add_card(mover);
         Ok(())
     } else {
-        Err(GameError::CardNotFound)
+        Err(CardError::CardNotFound.into())
     }
 }
 

--- a/src/dice.rs
+++ b/src/dice.rs
@@ -53,10 +53,14 @@ impl Die {
         })
     }
 
-    /// Create a non-exploding `Die` with specified number of sides, unchecked for
-    /// validity. Can be used in `const` contexts.
+    /// `Die` constructor that can be used in `const` contexts.
+    ///
+    /// # Panics
+    /// - compile time error to define a `Die` with zero sides
+    /// - panics if called with zero sides at runtime
     #[must_use]
-    pub const fn new_unchecked(sides: u64) -> Self {
+    pub const fn new_const(sides: u64) -> Self {
+        assert!(sides > 0, "a die with zero sides cannot be created");
         Self {
             sides,
             explode_on: None,
@@ -84,10 +88,24 @@ impl Die {
         })
     }
 
-    /// Create a exploding `Die` with specified number of sides, unchecked for
-    /// validity. Can be used in `const` contexts.
+    /// Create an exploding `Die` with spcified number of sides and trigger value.
+    ///
+    /// # Panics
+    /// - (or compile-time errors in const/static contexts)
+    /// - if attempt is made to create a die with < 2 sides
+    /// - if the explode trigger is not within the die's range
     #[must_use]
-    pub const fn exploding_unchecked(sides: u64, explode_on: u64) -> Self {
+    pub fn exploding_const(sides: u64, explode_on: u64) -> Self {
+        assert!(sides > 0, "a die with zero sides cannot be created");
+        assert!(
+            sides > 1,
+            "a die with one side would explode in an infinite loop"
+        );
+        assert!(
+            explode_on >= 1 && explode_on <= sides,
+            "explode trigger must be in range (1..=sides)"
+        );
+
         Self {
             sides,
             explode_on: Some(explode_on),

--- a/src/dominos.rs
+++ b/src/dominos.rs
@@ -244,6 +244,21 @@ impl Train {
         Ok(())
     }
 
+    /// Opens the train, allowing it to be played on.
+    pub fn open(&mut self) {
+        self.open = true;
+    }
+
+    /// Closes the train, preventing it from being played on.
+    pub fn close(&mut self) {
+        self.open = false;
+    }
+
+    /// Returns whether the train is open and can be played on.
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
     fn ensure_player_can_play(&self, player: &str) -> GameResult<()> {
         if !self.open && self.player != player {
             return Err(GameError::TrainClosed);

--- a/src/dominos.rs
+++ b/src/dominos.rs
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
-use crate::{GameError, GameResult};
+use crate::{DominoError, GameResult};
 
 /// The maximum number of pips allowed on each side of a domino.
 pub const MAX_PIPS: u8 = 18;
@@ -261,7 +261,7 @@ impl Train {
 
     fn ensure_player_can_play(&self, player: &str) -> GameResult<()> {
         if !self.open && self.player != player {
-            return Err(GameError::TrainClosed);
+            return Err(DominoError::TrainClosed.into());
         }
         Ok(())
     }
@@ -270,7 +270,7 @@ impl Train {
         match tile {
             _ if tile.left == tail => Ok(tile),
             _ if tile.right == tail => Ok(tile.flipped()),
-            _ => Err(GameError::TileUnconnected),
+            _ => Err(DominoError::TileUnconnected.into()),
         }
     }
 }
@@ -312,7 +312,7 @@ impl DominoHand {
                 tiles: starting_tiles,
             })
         } else {
-            Err(GameError::InsufficientTiles)
+            Err(DominoError::InsufficientTiles.into())
         }
     }
 
@@ -402,7 +402,7 @@ impl DominoHand {
             let pos = remaining_tiles
                 .iter()
                 .position(|&t| t.id == *domino_id)
-                .ok_or(GameError::TileNotFound(*domino_id))?;
+                .ok_or(DominoError::TileNotFound(*domino_id))?;
             let tile = remaining_tiles.swap_remove(pos);
             let tile = Train::oriented_for_tail(tile, tail)?;
             tail = tile.right;
@@ -637,7 +637,7 @@ mod domino_tests {
         let invalid_sequence = vec![0, 1, 2];
         assert_eq!(
             hand.play_line(&invalid_sequence, &mut train),
-            Err(GameError::TileUnconnected)
+            Err(DominoError::TileUnconnected.into())
         );
         assert_eq!(hand.tiles.len(), 3);
         assert!(train.tiles.is_empty());
@@ -652,7 +652,7 @@ mod domino_tests {
 
         assert_eq!(
             hand.play_line(&[0], &mut train),
-            Err(GameError::TrainClosed)
+            Err(DominoError::TrainClosed.into())
         );
         assert_eq!(hand.tiles.len(), 1);
         assert!(train.tiles.is_empty());

--- a/src/dominos.rs
+++ b/src/dominos.rs
@@ -237,17 +237,26 @@ impl Train {
     /// # Errors
     /// - if it isn't a valid play or if the train is closed and doesn't belong to the calling player.
     pub fn play(&mut self, tile: Domino, player: &str) -> GameResult<()> {
-        if !self.open && self.player != player {
-            return Err(GameError::TrainClosed);
-        }
-        let new_tile = match tile {
-            _ if tile.left == self.tail => tile,
-            _ if tile.right == self.tail => tile.flipped(),
-            _ => return Err(GameError::TileUnconnected),
-        };
+        self.ensure_player_can_play(player)?;
+        let new_tile = Self::oriented_for_tail(tile, self.tail)?;
         self.tail = new_tile.right;
         self.tiles.push(new_tile);
         Ok(())
+    }
+
+    fn ensure_player_can_play(&self, player: &str) -> GameResult<()> {
+        if !self.open && self.player != player {
+            return Err(GameError::TrainClosed);
+        }
+        Ok(())
+    }
+
+    fn oriented_for_tail(tile: Domino, tail: u8) -> GameResult<Domino> {
+        match tile {
+            _ if tile.left == tail => Ok(tile),
+            _ if tile.right == tail => Ok(tile.flipped()),
+            _ => Err(GameError::TileUnconnected),
+        }
     }
 }
 
@@ -351,22 +360,54 @@ impl DominoHand {
         }
     }
 
-    /// Takes a sequence of domino ids and attempt to play them on a train.
+    /// Takes a sequence of domino ids and attempts to play them on a train.
+    ///
+    /// The line is validated before either the hand or train is mutated. If any
+    /// tile is missing, does not connect, or cannot be played on the target train,
+    /// both objects are left unchanged.
     ///
     /// # Errors
     /// - if a tile in the sequence doesn't fit in the train
     /// - if the player doesn't have permission to play on the train
     /// - if one of the tiles in the sequence is missing from the hand
     pub fn play_line(&mut self, id_sequence: &[usize], train: &mut Train) -> GameResult<()> {
+        if id_sequence.is_empty() {
+            return Ok(());
+        }
+
+        train.ensure_player_can_play(&self.player)?;
+
+        // attempt to play the line using a copy of the hand's tiles first,
+        // in case the play is aborted by an error midway through the id_sequence
+        let mut remaining_tiles = self.tiles.clone();
+        let mut planned_tiles = Vec::with_capacity(id_sequence.len());
+        let mut tail = train.tail;
+
+        for domino_id in id_sequence {
+            let pos = remaining_tiles
+                .iter()
+                .position(|&t| t.id == *domino_id)
+                .ok_or(GameError::TileNotFound(*domino_id))?;
+            let tile = remaining_tiles.swap_remove(pos);
+            let tile = Train::oriented_for_tail(tile, tail)?;
+            tail = tile.right;
+            planned_tiles.push(tile);
+        }
+
+        // no errors -- proceed with transaction:
+        // remove needed dominos from the hand
         for domino_id in id_sequence {
             let pos = self
                 .tiles
                 .iter()
                 .position(|&t| t.id == *domino_id)
-                .ok_or(GameError::TileNotFound(*domino_id))?;
-            let tile = self.tiles.swap_remove(pos);
-            train.play(tile, &self.player)?;
+                .expect("validated tile must remain present during commit");
+            self.tiles.swap_remove(pos);
         }
+
+        // then extend the train with the planned tiles
+        train.tail = tail;
+        train.tiles.extend(planned_tiles);
         Ok(())
     }
 }
@@ -563,6 +604,44 @@ mod domino_tests {
 
         let bad_sequence = vec![9, 8, 9, 8]; // these domino ids aren't in the hand
         assert!(hand.play_line(&bad_sequence, &mut train).is_err());
+        assert_eq!(hand.tiles.len(), 3);
+        assert!(train.tiles.is_empty());
+        assert_eq!(train.tail, 1);
+    }
+
+    #[test]
+    fn hand_play_line_is_transactional_if_later_tile_does_not_connect() {
+        let mut hand = DominoHand::new("test");
+        hand.tiles = vec![
+            Domino::new(1, 2, 0),
+            Domino::new(9, 9, 1),
+            Domino::new(2, 3, 2),
+        ];
+        let mut train = Train::new("open", true, 1);
+
+        let invalid_sequence = vec![0, 1, 2];
+        assert_eq!(
+            hand.play_line(&invalid_sequence, &mut train),
+            Err(GameError::TileUnconnected)
+        );
+        assert_eq!(hand.tiles.len(), 3);
+        assert!(train.tiles.is_empty());
+        assert_eq!(train.tail, 1);
+    }
+
+    #[test]
+    fn hand_play_line_is_transactional_on_closed_train() {
+        let mut hand = DominoHand::new("guest");
+        hand.tiles = vec![Domino::new(1, 2, 0)];
+        let mut train = Train::new("owner", false, 1);
+
+        assert_eq!(
+            hand.play_line(&[0], &mut train),
+            Err(GameError::TrainClosed)
+        );
+        assert_eq!(hand.tiles.len(), 1);
+        assert!(train.tiles.is_empty());
+        assert_eq!(train.tail, 1);
     }
 
     #[test]

--- a/src/gameerror.rs
+++ b/src/gameerror.rs
@@ -1,21 +1,43 @@
 //! Shared error types used across the crate.
 //!
-//! [`GameError`] covers higher-level collection and gameplay failures, while [`DiceError`]
-//! keeps the dice module's validation errors specific and can be converted into
-//! [`GameError`] when needed.
+//! Module-specific errors stay narrow enough for callers to handle precisely,
+//! while [`GameError`] aggregates them for APIs that can surface failures from
+//! more than one subsystem.
 //!
 
 use thiserror::Error;
 
-/// Error types for problematic game conditions.
+/// Aggregate error type for APIs that may surface failures from multiple modules.
 #[derive(Debug, Error, PartialEq)]
 pub enum GameError {
+    #[error("card error: {0}")]
+    CardError(#[from] CardError),
+    #[error("domino error: {0}")]
+    DominoError(#[from] DominoError),
+    #[error("dice error: {0}")]
+    DiceError(#[from] DiceError),
+    #[error("refilling pool error: {0}")]
+    RefillingPoolError(#[from] RefillingPoolError),
+    #[error("spinner error: {0}")]
+    SpinnerError(#[from] SpinnerError),
+    #[error("value error: {0}")]
+    ValueError(#[from] ValueError),
+}
+
+/// Errors specific to card collections and card transfer helpers.
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum CardError {
     #[error("cannot draw from empty stack '{0}'")]
     StackEmpty(String),
     #[error("too few cards remain in '{0}' to satisfy need")]
     StackTooSmall(String),
     #[error("the card sought was not found in this collection")]
     CardNotFound,
+}
+
+/// Errors specific to domino hands, trains, and bone piles.
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum DominoError {
     #[error("insufficient tiles left in the bone pile")]
     InsufficientTiles,
     #[error("that tile does not match the tail of the train")]
@@ -24,20 +46,22 @@ pub enum GameError {
     TileNotFound(usize),
     #[error("attempted to play on a closed train")]
     TrainClosed,
+}
+
+/// Errors specific to spinners.
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum SpinnerError {
     #[error("spin() returned None: empty spinner or landed on covered wedge")]
     SpinnerEmpty,
-    #[error("attempted to roll zero dice into a DicePool")]
-    DicePoolWithNoDice,
-    #[error("attempted to create a die with zero sides")]
-    DieWithZeroSides,
+}
+
+/// Errors specific to [`crate::RefillingPool`].
+#[derive(Debug, Clone, Error, PartialEq)]
+pub enum RefillingPoolError {
     #[error("refilling pool must have items with which to refill")]
     PoolCannotBeEmpty,
     #[error("invalid index {0} for pool size {1}")]
     InvalidPoolIndex(usize, usize),
-    #[error("dice error: {0}")]
-    DiceError(#[from] DiceError),
-    #[error("value error: {0}")]
-    ValueError(#[from] ValueError),
 }
 
 /// Errors specific to creating and rolling dice.
@@ -62,51 +86,53 @@ pub enum ValueError {
 
 #[cfg(test)]
 mod tests {
-    use super::GameError;
+    use super::{
+        CardError, DiceError, DominoError, GameError, RefillingPoolError, SpinnerError, ValueError,
+    };
     use std::error::Error;
 
     #[test]
     fn test_game_error_display_and_trait() {
         let cases: Vec<(GameError, &str)> = vec![
             (
-                GameError::StackEmpty("Main".to_string()),
-                "cannot draw from empty stack 'Main'",
+                CardError::StackEmpty("Main".to_string()).into(),
+                "card error: cannot draw from empty stack 'Main'",
             ),
             (
-                GameError::StackTooSmall("Reserve".to_string()),
-                "too few cards remain in 'Reserve' to satisfy need",
+                CardError::StackTooSmall("Reserve".to_string()).into(),
+                "card error: too few cards remain in 'Reserve' to satisfy need",
             ),
             (
-                GameError::CardNotFound,
-                "the card sought was not found in this collection",
+                CardError::CardNotFound.into(),
+                "card error: the card sought was not found in this collection",
             ),
             (
-                GameError::InsufficientTiles,
-                "insufficient tiles left in the bone pile",
+                DominoError::InsufficientTiles.into(),
+                "domino error: insufficient tiles left in the bone pile",
             ),
             (
-                GameError::TileUnconnected,
-                "that tile does not match the tail of the train",
+                DominoError::TileUnconnected.into(),
+                "domino error: that tile does not match the tail of the train",
             ),
             (
-                GameError::TrainClosed,
-                "attempted to play on a closed train",
+                DominoError::TrainClosed.into(),
+                "domino error: attempted to play on a closed train",
             ),
             (
-                GameError::SpinnerEmpty,
-                "spin() returned None: empty spinner or landed on covered wedge",
+                SpinnerError::SpinnerEmpty.into(),
+                "spinner error: spin() returned None: empty spinner or landed on covered wedge",
             ),
             (
-                GameError::DicePoolWithNoDice,
-                "attempted to roll zero dice into a DicePool",
+                RefillingPoolError::PoolCannotBeEmpty.into(),
+                "refilling pool error: refilling pool must have items with which to refill",
             ),
             (
-                GameError::DieWithZeroSides,
-                "attempted to create a die with zero sides",
+                DiceError::DieWithNoSides.into(),
+                "dice error: a die with zero sides cannot be created",
             ),
             (
-                GameError::PoolCannotBeEmpty,
-                "refilling pool must have items with which to refill",
+                ValueError::OutOfRange.into(),
+                "value error: value outside valid range",
             ),
         ];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! - `refilling_pool`: infinitely reusable random pools with conditional and contextual draw helpers.
 //! - `spinners`: decision wheels with weighted, coverable wedges that can hold arbitrary values.
 //! - `dominos`: domino set creation, train management, and longest-train solving.
-//! - `GameError`, `DiceError`, and `GameResult` for shared error handling across the crate.
+//! - Module-specific error enums plus `GameError` / `GameResult` for aggregate error handling across the crate.
 
 pub mod cards;
 pub use cards::{
@@ -35,7 +35,9 @@ pub mod spinners;
 pub use spinners::{Spinner, Wedge, wedges_from_tuples, wedges_from_values};
 
 pub mod gameerror;
-pub use gameerror::{DiceError, GameError};
+pub use gameerror::{
+    CardError, DiceError, DominoError, GameError, RefillingPoolError, SpinnerError, ValueError,
+};
 pub type GameResult<T> = Result<T, GameError>;
 
 pub mod ordering;

--- a/src/refilling_pool.rs
+++ b/src/refilling_pool.rs
@@ -7,11 +7,12 @@
 //! thrice, etc.
 //!
 //! A `RefillingPool` can never be empty. Attempting to create an empty one or to remove
-//! the last item from one will generate a `GameError`.
+//! the last item from one will generate a [`RefillingPoolError`], surfaced through
+//! [`crate::GameError`] by the current public constructors.
 
 use rand::seq::SliceRandom as _;
 
-use crate::{GameResult, gameerror::GameError};
+use crate::{GameError, GameResult, RefillingPoolError};
 
 /// # `RefillingPool<T>`
 ///
@@ -65,7 +66,7 @@ impl<T> RefillingPool<T> {
     /// Create a new `RefillingPool` from an iterable collection.
     ///
     /// # Errors
-    /// - `GameError::PoolCannotBeEmpty` if `items` is empty.
+    /// - [`RefillingPoolError::PoolCannotBeEmpty`] if `items` is empty.
     ///
     /// # Examples
     /// ```
@@ -83,7 +84,7 @@ impl<T> RefillingPool<T> {
     pub fn new(items: impl IntoIterator<Item = T>) -> GameResult<Self> {
         let items: Vec<T> = items.into_iter().collect();
         if items.is_empty() {
-            return Err(GameError::PoolCannotBeEmpty);
+            return Err(RefillingPoolError::PoolCannotBeEmpty.into());
         }
         let mut unused: Vec<usize> = (0..items.len()).collect();
         unused.shuffle(&mut rand::rng());
@@ -128,10 +129,10 @@ impl<T> RefillingPool<T> {
     /// - `InvalidPoolIndex` if the supplied index is beyond current pool size.
     pub fn remove_index(&mut self, index: usize) -> GameResult<T> {
         if index >= self.items.len() {
-            return Err(GameError::InvalidPoolIndex(index, self.items.len()));
+            return Err(RefillingPoolError::InvalidPoolIndex(index, self.items.len()).into());
         }
         if self.items.len() == 1 {
-            return Err(GameError::PoolCannotBeEmpty);
+            return Err(RefillingPoolError::PoolCannotBeEmpty.into());
         }
         self.unused.retain(|&ui| ui != index);
         let item = self.items.swap_remove(index);
@@ -388,16 +389,21 @@ mod tests {
 
     #[test]
     fn creating_pool_with_no_refills_is_error() {
-        assert!(RefillingPool::<()>::new([]).is_err_and(|e| e.eq(&GameError::PoolCannotBeEmpty)));
+        assert!(RefillingPool::<()>::new([]).is_err_and(|e| {
+            e.eq(&GameError::RefillingPoolError(
+                RefillingPoolError::PoolCannotBeEmpty,
+            ))
+        }));
     }
 
     #[test]
     fn removing_last_item_is_error() {
         let mut pool = RefillingPool::new([1]).unwrap();
-        assert!(
-            pool.remove_index(0)
-                .is_err_and(|e| e.eq(&GameError::PoolCannotBeEmpty))
-        );
+        assert!(pool.remove_index(0).is_err_and(|e| {
+            e.eq(&GameError::RefillingPoolError(
+                RefillingPoolError::PoolCannotBeEmpty,
+            ))
+        }));
     }
 
     #[test]

--- a/src/spinners.rs
+++ b/src/spinners.rs
@@ -338,7 +338,9 @@ impl<T: Clone + PartialEq> Spinner<T> {
             .into_iter()
             .map(|w| {
                 if w.value == *match_val {
-                    Wedge::new_weighted(new_val.clone(), w.width)
+                    let mut new_w = Wedge::new_weighted(new_val.clone(), w.width);
+                    new_w.active = w.active;
+                    new_w
                 } else {
                     w
                 }
@@ -618,5 +620,17 @@ mod spinner_tests {
         let spinner = Spinner::new(vec![Wedge::new(apple.clone())]);
         let spinner = spinner.replace_value(&apple, &banana);
         assert_eq!(spinner.spin().unwrap(), banana);
+    }
+
+    #[test]
+    fn replace_value_preserves_covered_wedges() {
+        let spinner = Spinner::new(vec![Wedge::new("Lose").cover()]);
+
+        let spinner = spinner.replace_value(&"Lose", &"Try Again");
+        let wedge = &spinner.wedges()[0];
+
+        assert_eq!(wedge.value, "Try Again");
+        assert!(!wedge.active);
+        assert!(spinner.spin().is_none());
     }
 }


### PR DESCRIPTION
Few small improvements in existing modules in preparation for 0.9.0 release:

- `DominoHand::play_line()` is now transactional, so the hand isn't left in a partially-played state if there is an error mid-play
- `Spinner::replace_value()` now preserves any matching wedges' "active" state rather than resetting to `true` as a side effect
- fixed omission in public API that made it impossible to open/close a domino `Train`
- finished breaking overarching `GameError` into module-specific subtypes (still aggregated by `GameError`)
- fixed the `const` versions of `Die` constructors to prevent construction of invalid dice at compile time (previously warned user in docs but could still create them).